### PR TITLE
periodic algos should run the first time they are triggered

### DIFF
--- a/bt/algos.py
+++ b/bt/algos.py
@@ -98,12 +98,10 @@ class RunWeekly(Algo):
         # create pandas.Timestamp for useful .week property
         now = pd.Timestamp(now)
 
-        if self.last_date is None:
-            self.last_date = now
-            return False
-
         result = False
-        if now.week != self.last_date.week:
+        if self.last_date is None:
+            result = True
+        elif now.week != self.last_date.week:
             result = True
 
         self.last_date = now
@@ -137,12 +135,10 @@ class RunMonthly(Algo):
         if now is None:
             return False
 
-        if self.last_date is None:
-            self.last_date = now
-            return False
-
         result = False
-        if now.month != self.last_date.month:
+        if self.last_date is None:
+            result = True
+        elif now.month != self.last_date.month:
             result = True
 
         self.last_date = now
@@ -177,12 +173,10 @@ class RunQuarterly(Algo):
         if now is None:
             return False
 
-        if self.last_date is None:
-            self.last_date = now
-            return False
-
         result = False
-        if now.month != self.last_date.month and now.month % 3 == 1:
+        if self.last_date is None:
+            result = True
+        elif now.month != self.last_date.month and now.month % 3 == 1:
             result = True
 
         self.last_date = now
@@ -216,12 +210,10 @@ class RunYearly(Algo):
         if now is None:
             return False
 
-        if self.last_date is None:
-            self.last_date = now
-            return False
-
         result = False
-        if now.year != self.last_date.year:
+        if self.last_date is None:
+            result = True
+        elif now.year != self.last_date.year:
             result = True
 
         self.last_date = now


### PR DESCRIPTION
Not sure if this makes sense or if I'm using it wrong, but I found it a little awkward when comparing strategies that ran on different periods. A periodic strategy won't allocate or trade for the first full period, so two strategies running on different periods won't be directly comparable.

This change makes it so that periodic algos return True the first time they are triggered, in addition to the first day of the week/month/quarter/year.
