### PR TITLE
SelectN: NaN stats should not be selected

### DIFF
--- a/bt/algos.py
+++ b/bt/algos.py
@@ -451,7 +451,7 @@ class SelectN(Algo):
         self.all_or_none = all_or_none
 
     def __call__(self, target):
-        stat = target.temp['stat']
+        stat = target.temp['stat'].dropna()
         stat.sort(ascending=self.ascending)
 
         # handle percent n


### PR DESCRIPTION
Small fix: in `bt.algos.SelectN()` absent stats (NaN) should not be selected (i.e. it happens when running a momentum strategy on securities with different lengths of history).