### PR TITLE
ENH: Bankruptcy - better than raising "negative root node value"

### DIFF
--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -151,9 +151,10 @@ class Backtest(object):
         # loop through dates
         for dt in self.dates:
             self.strategy.update(dt)
-            self.strategy.run()
-            # need update after to save weights, values and such
-            self.strategy.update(dt)
+            if not self.strategy.bankrupt:
+                self.strategy.run()
+                # need update after to save weights, values and such
+                self.strategy.update(dt)
 
         self.stats = self.strategy.prices.calc_perf_stats()
         self._original_prices = self.strategy.prices


### PR DESCRIPTION
I think that declaring a bankruptcy for a strategy with negative `value` is better than raising an exception "negative root node value". When the strategy is being tuned - then we don't need to handle an exception in a special way - bankruptcy will provide a negative value/price/return/Sharpe that can be directly plugged into optimizer. 

For this I'm declaring a property `bt.core.StrategyBase.bankrupt` which is by default is `False`, but once the value dropped below zero is switched to `True`. All positions are immediately closed then (with proper fee accounting as well).

`bt.backtest.Backtest.run()` will do `self.strategy.run()` only if the strategy is not bankrupt, otherwise it will keep updating values up to the end of the `self.dates`.

Philippe, what do you think?

p.s. I did not make `bankrupt` to be a protected property with read-only getter - I think it just does not make sense here...