### PR TITLE
Children strategies should be copied for later reuse (fix for #19)

### DIFF
--- a/bt/core.py
+++ b/bt/core.py
@@ -75,7 +75,8 @@ class Node(object):
                             tmp[c] = SecurityBase(c)
                             ut.append(c)
                         else:
-                            tmp[c.name] = c
+                            # deepcopy object for possible later reuse
+                            tmp[c.name] = deepcopy(c)
 
                             # if strategy, turn on flag and add name to list
                             # strategy children have special treatment


### PR DESCRIPTION
Hopefully `deepcopy` is enough to fix #19.