### PR TITLE
Performance optimization: update(). Closes #24

### DIFF
--- a/bt/core.py
+++ b/bt/core.py
@@ -489,7 +489,7 @@ class StrategyBase(Node):
         # won't change
         if newpt or self._value != val:
             self._value = val
-            self._values.iat[inow] = val
+            self._values.values[inow] = val
 
             try:
                 ret = self._value / (self._last_value
@@ -509,7 +509,7 @@ class StrategyBase(Node):
                                              self._value))
 
             self._price = self._last_price * (1 + ret)
-            self._prices.iat[inow] = self._price
+            self._prices.values[inow] = self._price
 
         # update children weights
         if self.children is not None:
@@ -531,8 +531,8 @@ class StrategyBase(Node):
         # Cash should track the unallocated capital at the end of the day, so
         # we should update it every time we call "update".
         # Same for fees
-        self._cash.iat[inow] = self._capital
-        self._fees.iat[inow] = self._last_fee
+        self._cash.values[inow] = self._capital
+        self._fees.values[inow] = self._last_fee
 
         # update paper trade if necessary
         if newpt and self._paper_trade:
@@ -541,7 +541,7 @@ class StrategyBase(Node):
             self._paper.update(date)
             # update price
             self._price = self._paper.price
-            self._prices.iat[inow] = self._price
+            self._prices.values[inow] = self._price
 
     @cy.locals(amount=cy.double, update=cy.bint, flow=cy.bint, fees=cy.double)
     def adjust(self, amount, update=True, flow=True, fee=0.0):
@@ -880,18 +880,18 @@ class SecurityBase(Node):
             self.now = date
 
             if self._prices_set:
-                self._price = self._prices.iat[inow]
+                self._price = self._prices.values[inow]
             # traditional data update
             elif data is not None:
                 prc = data[self.name]
                 self._price = prc
-                self._prices.iat[inow] = prc
+                self._prices.values[inow] = prc
 
-        self._positions.iat[inow] = self._position
+        self._positions.values[inow] = self._position
         self._last_pos = self._position
 
         self._value = self._position * self._price * self.multiplier
-        self._values.iat[inow] = self._value
+        self._values.values[inow] = self._value
 
         if self._weight == 0 and self._position == 0:
             self._needupdate = False

--- a/bt/core.py
+++ b/bt/core.py
@@ -465,7 +465,10 @@ class StrategyBase(Node):
         # update now
         self.now = date
         if inow is None:
-            inow = self.data.index.get_loc(date)
+            if self.now == 0:
+                inow = 0
+            else:
+                inow = self.data.index.get_loc(date)
 
         # update children if any and calculate value
         val = self._capital  # default if no children
@@ -872,7 +875,10 @@ class SecurityBase(Node):
             return
 
         if inow is None:
-            inow = self.data.index.get_loc(date)
+            if date == 0:
+                inow = 0
+            else:
+                inow = self.data.index.get_loc(date)
 
         # date change - update price
         if date != self.now:


### PR DESCRIPTION
Hi Phil,

this PR optimizes `update()` of securities and strategies. Hopefully closes #24.

First commit (PERF-1) is **"non-intrusive"**: it does not change the default behavior, but uses optimized version of indexer (`.at`). It improves performance of simple strategies by ~3-4 times.

Other two commits (PERF-2 and PERF-3) are **"intrusive"**. They use even faster `.iat` and then `.values` for setting. But both of them operate only on integer indexes. Thus `inow` is introduced that gets the integer value by date.
However the most benefit this approach gives, when `inow` is passed to `.update()` of children, and thus is not calculated there. **BUT** this assumes that all `. _prices`, `._positions` and `._values` of all securities/strategies are aligned with the `.data` of the main strategy. 

As I understand, when strategy/backtest are created in the standard way, all indexes should be aligned: [here](https://github.com/pmorissette/bt/blob/master/bt/core.py#L420), [here](https://github.com/pmorissette/bt/blob/master/bt/core.py#L431) and [here] (https://github.com/pmorissette/bt/blob/master/bt/core.py#L845-L851).

But could you imagine a situation when indices could be mis-aligned?

