### PR TITLE
LimitWeights(): do nothing if weights is empty

### DIFF
--- a/bt/algos.py
+++ b/bt/algos.py
@@ -1020,6 +1020,9 @@ class LimitWeights(Algo):
             return True
 
         tw = target.temp['weights']
+        if len(tw) == 0:
+            return True
+        
         tw = bt.ffn.limit_weights(tw, self.limit)
         target.temp['weights'] = tw
 


### PR DESCRIPTION
if `target.temp['weights']` exists but is empty - do nothing (`return True`)