### PR TITLE
Allow for non-integer positions

### DIFF
--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -116,7 +116,8 @@ class Backtest(object):
     def __init__(self, strategy, data,
                  name=None,
                  initial_capital=1000000.0,
-                 commissions=None):
+                 commissions=None,
+                 integer_positions=True):
 
         if data.columns.duplicated().any():
             cols = data.columns[data.columns.duplicated().tolist()].tolist()
@@ -127,6 +128,8 @@ class Backtest(object):
         # we want to reuse strategy logic - copy it!
         # basically strategy is a template
         self.strategy = deepcopy(strategy)
+        self.strategy.use_integer_positions(integer_positions)
+
         self.data = data
         self.dates = data.index
         self.initial_capital = initial_capital


### PR DESCRIPTION
Partially related to issue #13 and PR #14.

Rounding positions to nearest integer (floor/ceil) eventually can pose some problems and unexpected results for backtesting on equity data.

Because of series of reverse splits of stocks, the adjusted prices back in time might be high. Thus rounding of desired amount of stocks to buy may lead to having 0, and thus ignoring this stock from backtesting.

Consider [YRC Worldwide Inc. (YRCW)](https://finance.yahoo.com/echarts?s=YRCW+Interactive#%7B%22range%22%3A%22max%22%2C%22scale%22%3A%22linear%22%7D). It had [two reverse splits in 2010 and 2011](https://finance.yahoo.com/q/hp?s=YRCW&a=06&b=9&c=1986&d=03&e=7&f=2015&g=v) with ratios 1:25 and 1:44. Thus the total split ratio is 1:1100 over this time. Because of this [adjusted price of this stock](https://finance.yahoo.com/q/hp?s=YRCW&a=06&b=9&c=1986&d=03&e=7&f=2005&g=d) is several hundreds of thousands back in 2000s and earlier, and backtesting with default initial capital of 1'000'000 will effectively exclude this stock from any portfolio of 3-4 or more stocks.

Indeed, increase of `initial_capital` might partially avoid this problem, but it's better to have a separate switch: anyway working with adjusted prices we should consider positions as adjusted positions, and it's OK to have them fractional.

