### PR TITLE
Numpy floating point error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ docs/_build/
 
 # notebooks
 docs/source/.ipynb_checkpoints/
+
+# ignore PyCharm and IntelliJ project metadata
+/.idea/

--- a/bt/algos.py
+++ b/bt/algos.py
@@ -1,6 +1,7 @@
 """
 A collection of Algos used to create Strategy logic.
 """
+from __future__ import division
 import bt
 from bt.core import Algo, AlgoStack
 import pandas as pd
@@ -1112,7 +1113,7 @@ class LimitWeights(Algo):
         tw = target.temp['weights']
         if len(tw) == 0:
             return True
-        
+
         tw = bt.ffn.limit_weights(tw, self.limit)
         target.temp['weights'] = tw
 

--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -1,6 +1,7 @@
 """
 Contains backtesting logic and objects.
 """
+from __future__ import division
 from copy import deepcopy
 import bt
 import ffn

--- a/bt/core.py
+++ b/bt/core.py
@@ -546,8 +546,9 @@ class StrategyBase(Node):
                 if c._issec and not c._needupdate:
                     continue
                 try:
-                    c._weight = c.value / val
-                except ZeroDivisionError:
+                    with np.errstate(divide='raise', invalid='raise'):
+                        c._weight = c.value / val
+                except (ZeroDivisionError, FloatingPointError):
                     c._weight = 0.0
 
         # if we have strategy children, we will need to update them in universe
@@ -976,7 +977,8 @@ class SecurityBase(Node):
         if amount == -self._value:
             q = -self._position
         else:
-            q = amount / (self._price * self.multiplier)
+            with np.errstate(divide='raise', invalid='raise'):
+                q = amount / (self._price * self.multiplier)
             if self.integer_positions:
                 if (self._position > 0) or ((self._position == 0) and (amount > 0)):
                     # if we're going long or changing long position

--- a/bt/core.py
+++ b/bt/core.py
@@ -1,6 +1,7 @@
 """
 Contains the core building blocks of the framework.
 """
+from __future__ import division
 import math
 from copy import deepcopy
 

--- a/bt/core.py
+++ b/bt/core.py
@@ -519,9 +519,10 @@ class StrategyBase(Node):
             self._values.values[inow] = val
 
             try:
-                ret = self._value / (self._last_value
-                                     + self._net_flows) - 1
-            except ZeroDivisionError:
+                with np.errstate(divide='raise', invalid='raise'):
+                    ret = self._value / (self._last_value
+                                         + self._net_flows) - 1
+            except (ZeroDivisionError, FloatingPointError):
                 if self._value == 0:
                     ret = 0
                 else:

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -1,3 +1,4 @@
+from __future__ import division
 from datetime import datetime
 
 import mock

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import bt
 import pandas as pd
 import mock

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import copy
 
 import bt


### PR DESCRIPTION
Hi Philippe,

Great backtesting framework - simple, elegant and flexible.

I found some problems around handling of floating point division in core.py. With numpy 1.9.2 and pandas 0.16.1 (latest as of this writing) on python 2.7.10, the following two unit tests fails:
* test_strategybase_tree_allocate_level2
* test_strategybase_tree_allocate_update

A bit of debugging reveals two issues:
* if both numerator and denominator are ints or np.int64, then an int or int64 is returned rather than a floating point, e.g. 2/3 = 0. This affects python 2 as python 2 behaves this way. I fixed this by adding a "from __future__ import division" statement on the top of every file. It could also be fixed by converting the divisor to a float, but I think the python 3 future import is simpler and less error prone.
* numpy array divisions not throwing ZeroDivisionError. By default numpy simply prints a warning and returns inf or nan. Since the framework code operates mostly on pandas dataframes, the underlying data will be a numpy structure. I fixed this by wrapping the relevant arithmetic block inside a np.errstate() context manager, specifying the error action to raise a FloatingPointError, then catching that in addition to ZeroDivisionError.

Regards

Ran
