### PR TITLE
Addition of Algo WeighERC()

### DIFF
--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -342,6 +342,34 @@ def test_select_has_data_preselected():
     assert len(selected) == 0
 
 
+@mock.patch('bt.ffn.calc_erc_weights')
+def test_weigh_mean_var(mock_erc):
+    algo = algos.WeighERC(lookback=pd.DateOffset(days=5))
+
+    mock_erc.return_value = pd.Series({'c1': 0.3, 'c2': 0.7})
+
+    s = bt.Strategy('s')
+
+    dts = pd.date_range('2010-01-01', periods=5)
+    data = pd.DataFrame(index=dts, columns=['c1', 'c2'], data=100.)
+
+    s.setup(data)
+    s.update(dts[4])
+    s.temp['selected'] = ['c1', 'c2']
+
+    assert algo(s)
+    assert mock_erc.called
+    rets = mock_erc.call_args[0][0]
+    assert len(rets) == 4
+    assert 'c1' in rets
+    assert 'c2' in rets
+
+    weights = s.temp['weights']
+    assert len(weights) == 2
+    assert weights['c1'] == 0.3
+    assert weights['c2'] == 0.7
+
+
 def test_weigh_inv_vol():
     algo = algos.WeighInvVol(lookback=pd.DateOffset(days=5))
 

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -343,7 +343,7 @@ def test_select_has_data_preselected():
 
 
 @mock.patch('bt.ffn.calc_erc_weights')
-def test_weigh_mean_var(mock_erc):
+def test_weigh_erc(mock_erc):
     algo = algos.WeighERC(lookback=pd.DateOffset(days=5))
 
     mock_erc.return_value = pd.Series({'c1': 0.3, 'c2': 0.7})


### PR DESCRIPTION
Addition of WeighERC() to algos.py which integrates ffn.calc_erc_weights() (https://github.com/pmorissette/ffn/pull/21) to calculate the portfolio weights which equate to having an equal risk contribution. The new algo and tests are based on the format of the existing algos WeighInvVol and WeighMeanVar.

The underlying function ffn.calc_erc_weights() draws heavily on examples and code provided in Roncalli (2013) and the solution uses a cyclical coordinate descent (CDD) algorithm described in detail in Griveau-Billion, 2013.