### PR TITLE
Correctly handle fractional positions when rebalancing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ docs/source/.ipynb_checkpoints/
 
 # ignore PyCharm and IntelliJ project metadata
 /.idea/
+*.iml

--- a/bt/core.py
+++ b/bt/core.py
@@ -1072,7 +1072,11 @@ class SecurityBase(Node):
             # if we get there
             i = 0
             while full_outlay > amount and q != 0:
-                q = q - 1
+                if self.integer_positions:
+                    q_delta = 1
+                else:
+                    q_delta = min(1., (full_outlay - amount) / self._price)
+                q = q - q_delta
                 full_outlay, _, _ = self.outlay(q)
                 i = i + 1
                 if i > 1e4:

--- a/bt/core.py
+++ b/bt/core.py
@@ -118,7 +118,7 @@ class Node(object):
         # set default value for now
         self.now = 0
         # make sure root has stale flag
-        # used to avoid unncessary update
+        # used to avoid unnecessary update
         # sometimes we change values in the tree and we know that we will need
         # to update if another node tries to access a given value (say weight).
         # This avoid calling the update until it is actually needed.
@@ -900,7 +900,7 @@ class SecurityBase(Node):
 
         """
         # if we already have all the prices, we will store them to speed up
-        # future udpates
+        # future updates
         try:
             prices = universe[self.name]
         except KeyError:
@@ -990,7 +990,7 @@ class SecurityBase(Node):
         buy/sell the security.
 
         A given amount of shares will be determined on the current price, a
-        commisison will be calculated based on the parent's commission fn, and
+        commission will be calculated based on the parent's commission fn, and
         any remaining capital will be passed back up  to parent as an
         adjustment.
 
@@ -1067,7 +1067,7 @@ class SecurityBase(Node):
             # per share > price per share. Howerver, we cannot really detect
             # that in advance since the function can be non-linear (say a fn
             # like max(1, abs(q) * 0.01). Nevertheless, we want to avoid these
-            # situtaions.
+            # situations.
             # cap the maximum number of iterations to 1e4 and raise exception
             # if we get there
             i = 0
@@ -1077,7 +1077,7 @@ class SecurityBase(Node):
                 i = i + 1
                 if i > 1e4:
                     raise Exception(
-                        'Potentially infinite loop detected. This occured '
+                        'Potentially infinite loop detected. This occurred '
                         'while trying to reduce the amount of shares purchased'
                         ' to respect the outlay <= amount rule. This is most '
                         'likely due to a commission function that outputs a '
@@ -1151,12 +1151,12 @@ class Algo(object):
     Algo should follow the unix philosophy - do one thing well.
 
     In practice, algos are simply a function that receives one argument, the
-    Strategy (refered to as target) and are expected to return a bool.
+    Strategy (referred to as target) and are expected to return a bool.
 
     When some state preservation is necessary between calls, the Algo
     object can be used (this object). The __call___ method should be
     implemented and logic defined therein to mimic a function call. A
-    simple function may also be used if no state preservation is neceesary.
+    simple function may also be used if no state preservation is necessary.
 
     Args:
         * name (str): Algo name
@@ -1200,7 +1200,7 @@ class AlgoStack(Algo):
                                     for x in self.algos)
 
     def __call__(self, target):
-        # normal runing mode
+        # normal running mode
         if not self.check_run_always:
             for algo in self.algos:
                 if not algo(target):
@@ -1247,8 +1247,10 @@ class Strategy(StrategyBase):
 
     """
 
-    def __init__(self, name, algos=[], children=None):
+    def __init__(self, name, algos=None, children=None):
         super(Strategy, self).__init__(name, children=children)
+        if algos is None:
+            algos = []
         self.stack = AlgoStack(*algos)
         self.temp = {}
         self.perm = {}

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
-from distutils.core import setup
-from distutils.extension import Extension
+from setuptools import setup
+from setuptools.extension import Extension
 import codecs
 import os
 import re

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,5 @@
 from __future__ import division
+
 import copy
 
 import bt
@@ -245,7 +246,7 @@ def test_update_fails_if_price_is_nan_and_position_open():
         c1.update(dts[i], data.ix[dts[i]])
         assert False
     except Exception as e:
-        assert e.message.startswith('Position is open')
+        assert str(e).startswith('Position is open')
 
     # on the other hand, if position was 0, this should be fine, and update
     # value to 0
@@ -1890,7 +1891,7 @@ def test_outlays():
     # out update
     s.update(dts[i])
 
-    print c1.data['outlay']
+    print(c1.data['outlay'])
     assert c1.data['outlay'][dts[1]] == (-4 * 100)
     assert c2.data['outlay'][dts[1]] == 100
 
@@ -2013,5 +2014,5 @@ def test_degenerate_shorting():
     try:
         c1.allocate(-10)
         assert False
-    except Exception, e:
-        assert 'infinite' in e.message
+    except Exception as e:
+        assert 'infinite' in str(e)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1431,6 +1431,32 @@ def test_strategybase_tree_rebalance():
     assert c2.weight == 0
 
 
+def test_strategybase_tree_decimal_position_rebalance():
+    c1 = SecurityBase('c1')
+    c2 = SecurityBase('c2')
+    s = StrategyBase('p', [c1, c2])
+    s.use_integer_positions(False)
+
+    c1 = s['c1']
+    c2 = s['c2']
+
+    dts = pd.date_range('2010-01-01', periods=3)
+    data = pd.DataFrame(index=dts, columns=['c1', 'c2'], data=100)
+
+    s.setup(data)
+
+    i = 0
+    s.update(dts[i], data.ix[dts[i]])
+
+    s.adjust(1000.2)
+    s.rebalance(0.42, 'c1')
+    s.rebalance(0.58, 'c2')
+
+    aae(c1.value, 420.084)
+    aae(c2.value, 580.116)
+    aae(c1.value + c2.value, 1000.2)
+
+
 def test_rebalance_child_not_in_tree():
     s = StrategyBase('p')
 


### PR DESCRIPTION
hey @pmorissette,

I found a bug (this may have been discussed in an earlier issue but I can't seem to find it) in bt related to the using non-integer positions. Basically, when the use_integer_positions flag is set to false, sometimes the allocation value for individual securities are off by a single share. The bit of code that does this is line 1074 in core.py. It looks like the assumption here is that q should always decrement by 1. But in the cases of decimal shares, due to floating point approximation issues, even when full_outlay should be theoretically exactly equal to amount, the condition "full_outlay > amount" might evaluate to true, hence causing the undesired effect of buying one less whole share.
```python
            while full_outlay > amount and q != 0:
                q = q - 1
```

This can be easily reproduced with the following unit tests (the sum of individual securities do not add up):
```python
def test_strategybase_tree_decimal_position_rebalance():
    c1 = SecurityBase('c1')
    c2 = SecurityBase('c2')
    s = StrategyBase('p', [c1, c2])
    s.use_integer_positions(False)

    c1 = s['c1']
    c2 = s['c2']

    dts = pd.date_range('2010-01-01', periods=3)
    data = pd.DataFrame(index=dts, columns=['c1', 'c2'], data=100)

    s.setup(data)

    i = 0
    s.update(dts[i], data.ix[dts[i]])

    s.adjust(1000.2)
    s.rebalance(0.42, 'c1')
    s.rebalance(0.58, 'c2')

    aae(c1.value, 420.084)
    aae(c2.value, 580.116)
    aae(c1.value + c2.value, 1000.2)
```

I'm proposing we fix this with the following bit of code:
```python
                if self.integer_positions:
                    q_delta = 1
                else:
                    q_delta = min(1., (full_outlay - amount) / self._price)
                q = q - q_delta
```

so if we are using integer_positions (default case), then decrement a single share as usual, otherwise we decrement by the smallest of either 1 share or a fractional q. In cases where the the condition gets hit due to floating point approximation issues, the above should code should be able to break out in a single iteration, and we get a correct decimal quantity.

What do you think? There may be a cleaner way to handle this!

BTW - would it be possible to add automated CI, such as Travis? It would be good to know from a glance  if all the tests are passing.
