### PR TITLE
Added new Or algo for control flow and fixed float comparisons for issue #137 and travis ci integration with nosetests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "2.7"
+  - "3.6"
+# command to install dependencies
+install:
+  - pip install -r requirements.txt
+# command to run tests
+script:
+  - test_algos.py # or py.test for Python versions 3.5 and below
+  - test_backtest.py
+  - test_core.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,4 @@ install:
   - pip install -r requirements.txt
 # command to run tests
 script:
-  - test_algos.py # or py.test for Python versions 3.5 and below
-  - test_backtest.py
-  - test_core.py
+  - nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   - pip install -r requirements.txt
 # command to run tests
 script:
-  - nosetests
+  - nosetests --with-coverage --cover-package bt

--- a/bt/algos.py
+++ b/bt/algos.py
@@ -1459,7 +1459,7 @@ class Or(Algo):
         runOnDateAlgo = bt.algos.RunOnDate(pdf.index[0]) # where pdf.index[0] is the first date in our time series
         runMonthlyAlgo = bt.algos.RunMonthly()
         orAlgo = Or([runMonthlyAlgo,runOnDateAlgo])
-        
+
     orAlgo will return True if it is the first date or if it is 1st of the month
 
     Args:

--- a/bt/algos.py
+++ b/bt/algos.py
@@ -1447,3 +1447,36 @@ class Require(Algo):
             return self.if_none
 
         return self.pred(item)
+
+
+class Or(Algo):
+    """
+    Flow control Algo
+
+    It useful for combining multiple signals into one signal.
+    For example, we might want two different rebalance signals to work together:
+
+        runOnDateAlgo = bt.algos.RunOnDate(pdf.index[0]) # where pdf.index[0] is the first date in our time series
+        runMonthlyAlgo = bt.algos.RunMonthly()
+        orAlgo = Or([runMonthlyAlgo,runOnDateAlgo])
+        
+    orAlgo will return True if it is the first date or if it is 1st of the month
+
+    Args:
+        * list_of_algos: Iterable list of algos.
+            Runs each algo and
+            returns true if any algo returns true.
+    """
+
+    def __init__(self, list_of_algos):
+        super(Or, self).__init__()
+        self._list_of_algos = list_of_algos
+        return
+
+    def __call__(self, target):
+        res = False
+        for algo in self._list_of_algos:
+            tempRes = algo(target)
+            res = res | tempRes
+
+        return res

--- a/bt/algos.py
+++ b/bt/algos.py
@@ -70,7 +70,7 @@ class PrintInfo(Algo):
         self.fmt_string = fmt_string
 
     def __call__(self, target):
-        print(self.fmt_string.format(target.__dict__))
+        print(self.fmt_string.format(**target.__dict__))
         return True
 
 

--- a/bt/core.py
+++ b/bt/core.py
@@ -1071,7 +1071,7 @@ class SecurityBase(Node):
             # cap the maximum number of iterations to 1e4 and raise exception
             # if we get there
             i = 0
-            while full_outlay > amount and q != 0:
+            while not np.isclose(full_outlay,amount,rtol=0.) and full_outlay > amount and q != 0:
                 q = q - 1
                 full_outlay, _, _ = self.outlay(q)
                 i = i + 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+ipython
+coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,9 @@
+cython
+future
+numpy
 pandas
+matplotlib
+ffn
+pyprind
 ipython
 coverage
-cython

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 ipython
 coverage
+cython

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -1,7 +1,13 @@
 from __future__ import division
 from datetime import datetime
 
-import mock
+import sys
+if sys.version_info < (3, 3):
+    import mock
+else:
+    from unittest import mock
+
+
 import pandas as pd
 import numpy as np
 from nose.tools import assert_almost_equal as aae

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -763,3 +763,40 @@ def test_run_every_n_periods_offset():
 
     target.now = pd.to_datetime('2010-01-05')
     assert algo(target)
+
+
+def test_or():
+    target = mock.MagicMock()
+    target.temp = {}
+
+    #run on the 1/2/18
+    runOnDateAlgo = algos.RunOnDate(pd.to_datetime('2018-01-02'))
+
+    #run on the first of the month
+    runMonthlyAlgo = algos.RunMonthly()
+    #initialize the first value
+    target.now = pd.to_datetime('2017-12-31')
+    runMonthlyAlgo(target)
+    orAlgo = algos.Or([runMonthlyAlgo, runOnDateAlgo])
+
+    #verify it returns true when runMonthly is true
+    target.now = pd.to_datetime('2018-01-01')
+    assert orAlgo(target)
+
+    # verify it returns true when runOnDate istrue
+    target.now = pd.to_datetime('2018-01-02')
+    assert orAlgo(target)
+
+    # verify it returns false when neither algo returns true
+    target.now = pd.to_datetime('2018-01-03')
+    assert not orAlgo(target)
+
+    # verify it returns true when both algos return true
+    target.now = pd.to_datetime('2018-02-01')
+    runOnDateAlgo = algos.RunOnDate(pd.to_datetime('2018-02-01'))
+    orAlgo = algos.Or([runMonthlyAlgo, runOnDateAlgo])
+    assert orAlgo(target)
+
+
+
+

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -2,7 +2,11 @@ from __future__ import division
 import bt
 import pandas as pd
 import numpy as np
-import mock
+import sys
+if sys.version_info < (3, 3):
+    import mock
+else:
+    from unittest import mock
 
 
 def test_backtest_copies_strategy():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,7 +6,11 @@ from bt.core import Node, StrategyBase, SecurityBase, AlgoStack, Strategy
 import pandas as pd
 import numpy as np
 from nose.tools import assert_almost_equal as aae
-import mock
+import sys
+if sys.version_info < (3, 3):
+    import mock
+else:
+    from unittest import mock
 
 
 def test_node_tree():
@@ -1890,7 +1894,7 @@ def test_outlays():
     # out update
     s.update(dts[i])
 
-    print c1.data['outlay']
+    print(c1.data['outlay'])
     assert c1.data['outlay'][dts[1]] == (-4 * 100)
     assert c2.data['outlay'][dts[1]] == 100
 
@@ -2013,7 +2017,7 @@ def test_degenerate_shorting():
     try:
         c1.allocate(-10)
         assert False
-    except Exception, e:
+    except Exception as e:
         assert 'infinite' in e.message
 
 def test_securitybase_allocate():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -249,7 +249,7 @@ def test_update_fails_if_price_is_nan_and_position_open():
         c1.update(dts[i], data.ix[dts[i]])
         assert False
     except Exception as e:
-        assert e.message.startswith('Position is open')
+        assert str(e).startswith('Position is open')
 
     # on the other hand, if position was 0, this should be fine, and update
     # value to 0
@@ -2018,7 +2018,7 @@ def test_degenerate_shorting():
         c1.allocate(-10)
         assert False
     except Exception as e:
-        assert 'infinite' in e.message
+        assert 'infinite' in str(e)
 
 def test_securitybase_allocate():
     c1 = SecurityBase('c1')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2015,3 +2015,37 @@ def test_degenerate_shorting():
         assert False
     except Exception, e:
         assert 'infinite' in e.message
+
+def test_securitybase_allocate():
+    c1 = SecurityBase('c1')
+    s = StrategyBase('p', [c1])
+
+    c1 = s['c1']
+
+    dts = pd.date_range('2010-01-01', periods=3)
+    data = pd.DataFrame(index=dts, columns=['c1'], data=100.)
+    # set the price
+    data['c1'][dts[0]] = 91.40246706608193
+    s.setup(data)
+
+    i = 0
+    s.update(dts[i], data.ix[dts[i]])
+
+    # allocate 100000 to strategy
+    original_capital = 100000.
+    s.adjust(original_capital)
+    #not integer positions
+    c1.integer_positions = False
+    #set the full_outlay and amount
+    full_outlay = 1999.693706988672
+    amount = 1999.6937069886717
+
+    c1.allocate(amount)
+
+    #the results that we want to be true
+    assert np.isclose(full_outlay ,amount,rtol=0.)
+
+    #check that the quantity wasn't decreased and the full_outlay == amount
+    #we can get the full_outlay that was calculated by
+    # original capital - current capital
+    assert np.isclose(full_outlay, original_capital - s._capital, rtol=0.)


### PR DESCRIPTION
The new Or algo is meant to provide flexibility when combining signals. For example, you may want multiple signals to trigger a rebalance.

Currently, if you want every signal to be true in order to rebalance(resembles a logical and), then you could chain them together in a row but there is no easy alternative for a logical or.