### PR TITLE
Run* Algos Overhaul

### DIFF
--- a/bt/algos.py
+++ b/bt/algos.py
@@ -3,6 +3,7 @@ A collection of Algos used to create Strategy logic.
 """
 from __future__ import division
 from future.utils import iteritems
+import abc
 import bt
 from bt.core import Algo, AlgoStack
 import pandas as pd
@@ -116,25 +117,10 @@ class RunOnce(Algo):
         return False
 
 
-class RunDaily(Algo):
-
-    """
-    Returns True on day change.
-
-    Args:
-        * run_on_first_call (bool): determines if it runs the first time the algo is called
-        * run_on_end_of_period (bool): determines if it should run at the end of the period
-          or the beginning
-        * run_on_last_call (bool): determines if it runs on the last time the algo is called
-
-    Returns True if the target.now's day has changed
-    compared to the last(or next if run_on_end_of_period) date, if not returns False.
-    Useful for daily rebalancing strategies.
-
-    """
+class RunPeriod(Algo):
 
     def __init__(self, run_on_first_date=True, run_on_end_of_period=False, run_on_last_date=False):
-        super(RunDaily, self).__init__()
+        super(RunPeriod, self).__init__()
         self._run_on_first_date = run_on_first_date
         self._run_on_end_of_period = run_on_end_of_period
         self._run_on_last_date = run_on_last_date
@@ -176,22 +162,47 @@ class RunDaily(Algo):
             date_to_compare = target.data.index[index + index_offset]
             date_to_compare = pd.Timestamp(date_to_compare)
 
-            if now.date() != date_to_compare.date():
-                result = True
+            result = self.compare_dates(now, date_to_compare)
 
         return result
 
+    @abc.abstractmethod
+    def compare_dates(self, now, date_to_compare):
+        raise(NotImplementedError('RunPeriod Algo is an abstract class!'))
 
-class RunWeekly(Algo):
+
+class RunDaily(RunPeriod):
+
+    """
+    Returns True on day change.
+
+    Args:
+        * run_on_first_date (bool): determines if it runs the first time the algo is called
+        * run_on_end_of_period (bool): determines if it should run at the end of the period
+          or the beginning
+        * run_on_last_date (bool): determines if it runs on the last time the algo is called
+
+    Returns True if the target.now's day has changed
+    compared to the last(or next if run_on_end_of_period) date, if not returns False.
+    Useful for daily rebalancing strategies.
+
+    """
+    def compare_dates(self, now, date_to_compare):
+        if now.date() != date_to_compare.date():
+            return True
+        return False
+
+
+class RunWeekly(RunPeriod):
 
     """
     Returns True on week change.
 
     Args:
-        * run_on_first_call (bool): determines if it runs the first time the algo is called
+        * run_on_first_date (bool): determines if it runs the first time the algo is called
         * run_on_end_of_period (bool): determines if it should run at the end of the period
           or the beginning
-        * run_on_last_call (bool): determines if it runs on the last time the algo is called
+        * run_on_last_date (bool): determines if it runs on the last time the algo is called
 
     Returns True if the target.now's week has changed
     since relative to the last(or next) date, if not returns False. Useful for
@@ -199,185 +210,77 @@ class RunWeekly(Algo):
 
     """
 
-    def __init__(self, run_on_first_date=True, run_on_end_of_period=False, run_on_last_date=False):
-        super(RunWeekly, self).__init__()
-        self._run_on_first_date = run_on_first_date
-        self._run_on_end_of_period = run_on_end_of_period
-        self._run_on_last_date = run_on_last_date
+    def compare_dates(self, now, date_to_compare):
+        if now.year != date_to_compare.year or now.week != date_to_compare.week:
+            return True
+        return False
 
-    def __call__(self, target):
-        # get last date
-        now = target.now
-
-        # if none nothing to do - return false
-        if now is None:
-            return False
-
-        # not a known date in our universe
-        if now not in target.data.index:
-            return False
-
-        # get index of the current date
-        index = target.data.index.get_loc(target.now)
-
-        result = False
-
-        # first date
-        if index == 0:
-            if self._run_on_first_date:
-                result = True
-        # last date
-        elif index == (len(target.data.index) - 1):
-            if self._run_on_last_date:
-                result = True
-        else:
-            # create pandas.Timestamp for useful .week,.quarter properties
-            now = pd.Timestamp(now)
-
-            index_offset = -1
-            if self._run_on_end_of_period:
-                index_offset = 1
-
-            date_to_compare = target.data.index[index + index_offset]
-            date_to_compare = pd.Timestamp(date_to_compare)
-
-            if now.year != date_to_compare.year or now.week != date_to_compare.week:
-                result = True
-
-        return result
-
-
-class RunMonthly(Algo):
+class RunMonthly(RunPeriod):
 
     """
     Returns True on month change.
 
     Args:
-        * run_on_first_call: bool which determines if it runs the first time the algo is called
+        * run_on_first_date (bool): determines if it runs the first time the algo is called
+        * run_on_end_of_period (bool): determines if it should run at the end of the period
+          or the beginning
+        * run_on_last_date (bool): determines if it runs on the last time the algo is called
 
     Returns True if the target.now's month has changed
-    since the last run, if not returns False. Useful for
+    since relative to the last(or next) date, if not returns False. Useful for
     monthly rebalancing strategies.
-
-    Note:
-        This algo will typically run on the first day of the
-        month (assuming we have daily data)
 
     """
 
-    def __init__(self, run_on_first_call=True):
-        super(RunMonthly, self).__init__()
-        self.last_date = None
-        self._run_on_first_call = run_on_first_call
-
-    def __call__(self, target):
-        # get last date
-        now = target.now
-
-        # if none nothing to do - return false
-        if now is None:
-            return False
-
-        result = False
-        if self.last_date is None:
-            result = self._run_on_first_call
-        elif now.year != self.last_date.year:
-            result = True
-        elif now.month != self.last_date.month:
-            result = True
-
-        self.last_date = now
-        return result
+    def compare_dates(self, now, date_to_compare):
+        if now.year != date_to_compare.year or now.month != date_to_compare.month:
+            return True
+        return False
 
 
-class RunQuarterly(Algo):
+class RunQuarterly(RunPeriod):
 
     """
     Returns True on quarter change.
 
     Args:
-        * run_on_first_call: bool which determines if it runs the first time the algo is called
+        * run_on_first_date (bool): determines if it runs the first time the algo is called
+        * run_on_end_of_period (bool): determines if it should run at the end of the period
+          or the beginning
+        * run_on_last_date (bool): determines if it runs on the last time the algo is called
 
-    Returns True if the target.now's month has changed
-    since the last run and the month is the first month
-    of the quarter, if not returns False. Useful for
+    Returns True if the target.now's quarter has changed
+    since relative to the last(or next) date, if not returns False. Useful for
     quarterly rebalancing strategies.
-
-    Note:
-        This algo will typically run on the first day of the
-        quarter (assuming we have daily data)
 
     """
 
-    def __init__(self, run_on_first_call=True):
-        super(RunQuarterly, self).__init__()
-        self.last_date = None
-        self._run_on_first_call = run_on_first_call
+    def compare_dates(self, now, date_to_compare):
+        if now.year != date_to_compare.year or now.quarter != date_to_compare.quarter:
+            return True
+        return False
 
-    def __call__(self, target):
-        # get last date
-        now = target.now
-
-        # if none nothing to do - return false
-        if now is None:
-            return False
-
-        # create pandas.Timestamp for useful .quarter property
-        now = pd.Timestamp(now)
-
-        result = False
-        if self.last_date is None:
-            result = self._run_on_first_call
-        elif now.year != self.last_date.year:
-            result = True
-        elif now.month != self.last_date.month and now.quarter != self.last_date.quarter:
-            result = True
-
-        self.last_date = now
-        return result
-
-
-class RunYearly(Algo):
+class RunYearly(RunPeriod):
 
     """
     Returns True on year change.
 
     Args:
-        * run_on_first_call: bool which determines if it runs the first time the algo is called
+        * run_on_first_date (bool): determines if it runs the first time the algo is called
+        * run_on_end_of_period (bool): determines if it should run at the end of the period
+          or the beginning
+        * run_on_last_date (bool): determines if it runs on the last time the algo is called
 
     Returns True if the target.now's year has changed
-    since the last run, if not returns False. Useful for
+    since relative to the last(or next) date, if not returns False. Useful for
     yearly rebalancing strategies.
-
-    Note:
-        This algo will typically run on the first day of the
-        year (assuming we have daily data)
 
     """
 
-    def __init__(self, run_on_first_call=True):
-        super(RunYearly, self).__init__()
-        self.last_date = None
-        self._run_on_first_call = run_on_first_call
-
-    def __call__(self, target):
-        # get last date
-        now = target.now
-
-        # if none nothing to do - return false
-        if now is None:
-            return False
-
-        result = False
-        if self.last_date is None:
-            result = self._run_on_first_call
-        elif now.year != self.last_date.year:
-            result = True
-        elif now.year != self.last_date.year:
-            result = True
-
-        self.last_date = now
-        return result
+    def compare_dates(self, now, date_to_compare):
+        if now.year != date_to_compare.year:
+            return True
+        return False
 
 
 class RunOnDate(Algo):

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -59,44 +59,134 @@ def test_run_once():
     assert not algo(None)
 
 
-def test_run_weekly():
-    algo = algos.RunWeekly()
-
+def test_run_daily():
     target = mock.MagicMock()
+
+    dts = pd.date_range('2010-01-01', periods=35)
+    data = pd.DataFrame(index=dts, columns=['c1', 'c2'], data=100)
+
+    target.data = data
+
+    algo = algos.RunDaily()
 
     target.now = None
     assert not algo(target)
 
-    target.now = datetime(2010, 1, 1)
+    # run on first date
+    target.now = dts[0]
     assert algo(target)
 
-    target.now = datetime(2010, 1, 15)
+    target.now = dts[1]
     assert algo(target)
 
-    target.now = datetime(2010, 2, 15)
-    assert algo(target)
-
-    # sat
-    target.now = datetime(2014, 1, 4)
-    assert algo(target)
-
-    # sun
-    target.now = datetime(2014, 1, 5)
+    # run on last date
+    target.now = dts[len(dts) - 1]
     assert not algo(target)
 
-    # mon - week change
-    target.now = datetime(2014, 1, 6)
+    algo = algos.RunDaily(
+        run_on_first_date=False,
+        run_on_end_of_period=True,
+        run_on_last_date=True
+    )
+
+    # run on first date
+    target.now = dts[0]
+    assert not algo(target)
+
+    target.now = dts[1]
     assert algo(target)
 
-    # check run first time
-    algo = algos.RunWeekly(run_on_first_call=False)
+    # run on last date
+    target.now = dts[len(dts) - 1]
+    assert algo(target)
 
-    target.now = datetime(2010, 1, 1)
+    # date not in index
+    target.now = datetime(2009, 2, 15)
     assert not algo(target)
+
+
+
+def test_run_weekly():
+    dts = pd.date_range('2010-01-01', periods=367)
+    data = pd.DataFrame(index=dts, columns=['c1', 'c2'], data=100)
+
+    target = mock.MagicMock()
+    target.data = data
+
+    algo = algos.RunWeekly()
+
+    target.now = None
+    assert not algo(target)
+
+    # run on first date
+    target.now = dts[0]
+    assert algo(target)
+
+    target.now = dts[1]
+    assert not algo(target)
+
+    # end of week
+    target.now = dts[2]
+    assert not algo(target)
+
+    # new week
+    target.now = dts[3]
+    assert algo(target)
+
+    # last date
+    target.now = dts[len(dts) - 1]
+    assert not algo(target)
+
+    algo = algos.RunWeekly(
+        run_on_first_date=False,
+        run_on_end_of_period=True,
+        run_on_last_date=True
+    )
+
+    # run on first date
+    target.now = dts[0]
+    assert not algo(target)
+
+    target.now = dts[1]
+    assert not algo(target)
+
+    # end of week
+    target.now = dts[2]
+    assert algo(target)
+
+    # new week
+    target.now = dts[3]
+    assert not algo(target)
+
+    # last date
+    target.now = dts[len(dts) - 1]
+    assert algo(target)
+
+    dts = pd.DatetimeIndex([datetime(2016, 1, 3), datetime(2017, 1, 8),datetime(2018, 1, 7)])
+    data = pd.DataFrame(index=dts, columns=['c1', 'c2'], data=100)
+    target.data = data
 
     # check next year
-    target.now = datetime(2012, 1, 1)
+    target.now = dts[1]
     assert algo(target)
+
+def test_run_end_of_period():
+    dts = pd.date_range('2010-01-01', periods=35)
+    data = pd.DataFrame(index=dts, columns=['c1', 'c2'], data=100)
+    data['c1'][dts[1]] = 105
+    data['c2'][dts[1]] = 95
+
+    algo = algos.RunDaily()
+    s = bt.Strategy(
+        's',
+        [algo]
+    )
+    s.setup(data)
+    s.update(dts[0])
+    s.run()
+
+
+
 
 
 def test_run_monthly():

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -170,124 +170,191 @@ def test_run_weekly():
     target.now = dts[1]
     assert algo(target)
 
-def test_run_end_of_period():
-    dts = pd.date_range('2010-01-01', periods=35)
-    data = pd.DataFrame(index=dts, columns=['c1', 'c2'], data=100)
-    data['c1'][dts[1]] = 105
-    data['c2'][dts[1]] = 95
-
-    algo = algos.RunDaily()
-    s = bt.Strategy(
-        's',
-        [algo]
-    )
-    s.setup(data)
-    s.update(dts[0])
-    s.run()
-
-
-
-
 
 def test_run_monthly():
-    algo = algos.RunMonthly()
+    dts = pd.date_range('2010-01-01', periods=367)
+    data = pd.DataFrame(index=dts, columns=['c1', 'c2'], data=100)
 
     target = mock.MagicMock()
+    target.data = data
+
+    algo = algos.RunMonthly()
 
     target.now = None
     assert not algo(target)
 
-    target.now = datetime(2010, 1, 1)
+    # run on first date
+    target.now = dts[0]
     assert algo(target)
 
-    target.now = datetime(2010, 1, 15)
+    target.now = dts[1]
     assert not algo(target)
 
-    target.now = datetime(2010, 2, 15)
-    assert algo(target)
-
-    target.now = datetime(2010, 2, 25)
+    # end of month
+    target.now = dts[30]
     assert not algo(target)
 
-    target.now = datetime(2010, 12, 25)
+    # new month
+    target.now = dts[31]
     assert algo(target)
 
-    target.now = datetime(2011, 1, 25)
-    assert algo(target)
-
-    # check run first time
-    algo = algos.RunMonthly(run_on_first_call=False)
-
-    target.now = datetime(2010, 1, 1)
+    # last date
+    target.now = dts[len(dts) - 1]
     assert not algo(target)
+
+    algo = algos.RunMonthly(
+        run_on_first_date=False,
+        run_on_end_of_period=True,
+        run_on_last_date=True
+    )
+
+    # run on first date
+    target.now = dts[0]
+    assert not algo(target)
+
+    target.now = dts[1]
+    assert not algo(target)
+
+    # end of month
+    target.now = dts[30]
+    assert algo(target)
+
+    # new month
+    target.now = dts[31]
+    assert not algo(target)
+
+    # last date
+    target.now = dts[len(dts) - 1]
+    assert algo(target)
+
+    dts = pd.DatetimeIndex([datetime(2016, 1, 3), datetime(2017, 1, 8), datetime(2018, 1, 7)])
+    data = pd.DataFrame(index=dts, columns=['c1', 'c2'], data=100)
+    target.data = data
 
     # check next year
-    target.now = datetime(2012, 1, 1)
+    target.now = dts[1]
     assert algo(target)
 
 
 def test_run_quarterly():
-    algo = algos.RunQuarterly()
+    dts = pd.date_range('2010-01-01', periods=367)
+    data = pd.DataFrame(index=dts, columns=['c1', 'c2'], data=100)
 
     target = mock.MagicMock()
+    target.data = data
+
+    algo = algos.RunQuarterly()
 
     target.now = None
     assert not algo(target)
 
-    target.now = datetime(2010, 1, 1)
+    # run on first date
+    target.now = dts[0]
     assert algo(target)
 
-    target.now = datetime(2010, 1, 15)
+    target.now = dts[1]
     assert not algo(target)
 
-    target.now = datetime(2010, 3, 31)
+    # end of quarter
+    target.now = dts[89]
     assert not algo(target)
 
-    target.now = datetime(2010, 4, 1)
+    # new quarter
+    target.now = dts[90]
     assert algo(target)
 
-    target.now = datetime(2010, 7, 2)
-    assert algo(target)
-
-    target.now = datetime(2010, 12, 25)
-    assert algo(target)
-
-    target.now = datetime(2011, 1, 25)
-    assert algo(target)
-
-    # check run first time
-    algo = algos.RunQuarterly(run_on_first_call=False)
-
-    target.now = datetime(2010, 1, 1)
+    # last date
+    target.now = dts[len(dts) - 1]
     assert not algo(target)
+
+    algo = algos.RunQuarterly(
+        run_on_first_date=False,
+        run_on_end_of_period=True,
+        run_on_last_date=True
+    )
+
+    # run on first date
+    target.now = dts[0]
+    assert not algo(target)
+
+    target.now = dts[1]
+    assert not algo(target)
+
+    # end of quarter
+    target.now = dts[89]
+    assert algo(target)
+
+    # new quarter
+    target.now = dts[90]
+    assert not algo(target)
+
+    # last date
+    target.now = dts[len(dts) - 1]
+    assert algo(target)
+
+    dts = pd.DatetimeIndex([datetime(2016, 1, 3), datetime(2017, 1, 8), datetime(2018, 1, 7)])
+    data = pd.DataFrame(index=dts, columns=['c1', 'c2'], data=100)
+    target.data = data
 
     # check next year
-    target.now = datetime(2012, 1, 1)
+    target.now = dts[1]
     assert algo(target)
 
 
 def test_run_yearly():
-    algo = algos.RunYearly()
+    dts = pd.date_range('2010-01-01', periods=367)
+    data = pd.DataFrame(index=dts, columns=['c1', 'c2'], data=100)
 
     target = mock.MagicMock()
+    target.data = data
 
-    target.now = datetime(2010, 1, 1)
-    assert algo(target)
+    algo = algos.RunYearly()
 
-    target.now = datetime(2010, 5, 1)
+    target.now = None
     assert not algo(target)
 
-    target.now = datetime(2011, 1, 1)
+    # run on first date
+    target.now = dts[0]
     assert algo(target)
 
-    # check run first time
-    algo = algos.RunYearly(run_on_first_call=False)
-
-    target.now = datetime(2010, 1, 1)
+    target.now = dts[1]
     assert not algo(target)
 
-    # check next year
-    target.now = datetime(2012, 1, 1)
+    # end of year
+    target.now = dts[364]
+    assert not algo(target)
+
+    # new year
+    target.now = dts[365]
+    assert algo(target)
+
+    # last date
+    target.now = dts[len(dts) - 1]
+    assert not algo(target)
+
+    algo = algos.RunYearly(
+        run_on_first_date=False,
+        run_on_end_of_period=True,
+        run_on_last_date=True
+    )
+
+    # run on first date
+    target.now = dts[0]
+    assert not algo(target)
+
+    target.now = dts[1]
+    assert not algo(target)
+
+    # end of year
+    target.now = dts[364]
+    assert algo(target)
+
+    # new year
+    target.now = dts[365]
+    assert not algo(target)
+
+    # last date
+    target.now = dts[len(dts) - 1]
     assert algo(target)
 
 
@@ -928,30 +995,26 @@ def test_or():
 
     #run on the 1/2/18
     runOnDateAlgo = algos.RunOnDate(pd.to_datetime('2018-01-02'))
+    runOnDateAlgo2 = algos.RunOnDate(pd.to_datetime('2018-01-03'))
+    runOnDateAlgo3 = algos.RunOnDate(pd.to_datetime('2018-01-04'))
+    runOnDateAlgo4 = algos.RunOnDate(pd.to_datetime('2018-01-04'))
 
-    #run on the first of the month
-    runMonthlyAlgo = algos.RunMonthly()
-    #initialize the first value
-    target.now = pd.to_datetime('2017-12-31')
-    runMonthlyAlgo(target)
-    orAlgo = algos.Or([runMonthlyAlgo, runOnDateAlgo])
+    orAlgo = algos.Or([runOnDateAlgo, runOnDateAlgo2, runOnDateAlgo3, runOnDateAlgo4])
 
-    #verify it returns true when runMonthly is true
+    #verify it returns false when neither is true
     target.now = pd.to_datetime('2018-01-01')
-    assert orAlgo(target)
+    assert not orAlgo(target)
 
-    # verify it returns true when runOnDate istrue
+    # verify it returns true when the first is true
     target.now = pd.to_datetime('2018-01-02')
     assert orAlgo(target)
 
-    # verify it returns false when neither algo returns true
+    # verify it returns true when the second is true
     target.now = pd.to_datetime('2018-01-03')
-    assert not orAlgo(target)
+    assert orAlgo(target)
 
     # verify it returns true when both algos return true
-    target.now = pd.to_datetime('2018-02-01')
-    runOnDateAlgo = algos.RunOnDate(pd.to_datetime('2018-02-01'))
-    orAlgo = algos.Or([runMonthlyAlgo, runOnDateAlgo])
+    target.now = pd.to_datetime('2018-01-04')
     assert orAlgo(target)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2115,19 +2115,9 @@ def test_securitybase_allocate_commisions():
                                     bt.algos.RunDaily(),
                                     bt.algos.Rebalance()])
 
-    #### now we create the Backtest , commissions=(lambda q, p: abs(p * q) * comms)
-    t = bt.Backtest(
-        s1,
-        price,
-        initial_capital=1000000,
-        commissions=(lambda q, p: abs(p * q) * comms),
-        progress_bar=False
-    )
+    ####now we create the Backtest , commissions=(lambda q, p: abs(p * q) * comms)
+    t = bt.Backtest(s1, price, initial_capital=1000000, commissions=(lambda q, p: abs(p * q) * comms), progress_bar=False)
 
-    #### and let's run it!
-    try:
-        res = bt.run(t)
-        assert True
-    except Exception as e:
-        assert False
+    ####and let's run it!
+    res = bt.run(t)
     ########################


### PR DESCRIPTION
Changed Run* Algos to use universe of dates to decide if it is the end or beginning of a period. 

It has the ability to run on the first date or the last date instead of running on the first call or the last call. It also has ability to run on either the first of the period or the last of the period.

The biggest difference will be if the algo doesn't run on the first(or last if run_on_end_of_period == True) date in the period, then it will not run at all. For example, if you have a RunMonthly algo with run_on_end_of_period == False and it does not run on the first date in the month from the universe of dates it was given because an algo before it in the stack returned False, then it will not run all month. If the Run* algo is at the beginning of stack, then there is no difference. 

This logic seems more intuitive for me but I thought I would ask the community first.
@FinQuest 
@pmorissette 
