### PR TITLE
Fix for invalid syntax in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,5 @@ setup(
         'Programming Language :: Python'
     ],
     ext_modules=ext_modules,
-    python_requires='=2.7, =3.4, =3.5, =3.6'
+    python_requires='>=2.7, >=3.4'
 )


### PR DESCRIPTION
The commit 01d70cbaafaec1ba60a1c27454d3d3b686510a66 changed
the syntax for `python_requires`, to an invalid syntax
according to PEP 345 and PEP 440. Basicly, the '=' operator
will cause an error when setuptools runs because it is not
acceptable as per the guidelines in PEP 345. This commit
should do the trick and hopefully does what the developer
intended.