### PR TITLE
normed has been deprecated since mpl 2.1, using density instead

### DIFF
--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -528,7 +528,7 @@ class RandomBenchmarkResult(Result):
 
         ser = self.r_stats.ix[statistic]
 
-        ax = ser.hist(bins=bins, figsize=figsize, normed=True, **kwargs)
+        ax = ser.hist(bins=bins, figsize=figsize, density=True, **kwargs)
         ax.set_title(title)
         plt.axvline(self.b_stats[statistic], linewidth=4)
         ser.plot(kind='kde')


### PR DESCRIPTION
The `normed` keyword has been deprecated in Matplotlib 2.1. Switching to `density` so as to avoid warnings like 
```
/Users/mirca/miniconda3/lib/python3.7/site-packages/pandas/plotting/_matplotlib/hist.py:316: MatplotlibDeprecationWarning: 
The 'normed' kwarg was deprecated in Matplotlib 2.1 and will be removed in 3.1. Use 'density' instead.
  ax.hist(values, bins=bins, **kwds)
```