### PR TITLE
positions should not mix NaN and 0s

### DIFF
--- a/bt/core.py
+++ b/bt/core.py
@@ -412,7 +412,7 @@ class StrategyBase(Node):
 
         vals = pd.DataFrame({x.name: x.positions for x in self.members
                              if isinstance(x, SecurityBase)})
-        self._positions = vals
+        self._positions = vals.fillna(0.0)
         return vals
 
     def setup(self, universe):


### PR DESCRIPTION
I propose a simple fix to the fact that the `positions` property for `StrategyBase` class in a situation when a position was opened and then closed returns NaN for the current date for the closed positions. 

This is not coherent with the behaviour of the property for the past, i.e. positions that open mid-backtest have zero positions filled from the backtest start to the current moment. 

Alternative fix would be to change line 884, so `positions` property of `SecurityBase` to:
`return self._positions.loc[:self.>root.<now]
 but I think it would be less efficient and clumsy. 

For the purposes when you just want to print the positions timeseries, having it coherently filled with zeros when you, well, have zero position in a security would be optimal.