### PR TITLE
Delete deprecated .ix in .plot_histogram()

### DIFF
--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -526,9 +526,9 @@ class RandomBenchmarkResult(Result):
 
         plt.figure(figsize=figsize)
 
-        ser = self.r_stats.ix[statistic]
+        ser = self.r_stats.loc[statistic]
 
         ax = ser.hist(bins=bins, figsize=figsize, density=True, **kwargs)
         ax.set_title(title)
-        plt.axvline(self.b_stats[statistic], linewidth=4)
+        plt.axvline(self.b_stats[statistic], linewidth=4, color = 'r')
         ser.plot(kind='kde')


### PR DESCRIPTION
Added contrasting color to the line so that it stands out. Was default and blended in with the histogram.