### PR TITLE
Performance improvements

### DIFF
--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -496,7 +496,7 @@ class Result(ffn.GroupStats):
 
         # Adjust prices for bid/offer paid if needed
         if s._bidoffer_set:
-            bidoffer = pd.DataFrame({x.name: x.bidoffer_paid
+            bidoffer = pd.DataFrame({x.name: x.bidoffers_paid
                                      for x in s.securities }).unstack()
             prc += bidoffer / trades
 

--- a/examples/fixed_income.ipynb
+++ b/examples/fixed_income.ipynb
@@ -358,8 +358,8 @@
     "    bt.algos.Or( [bt.algos.RunWeekly(), \n",
     "                  bt.algos.RunMonthly()] ),\n",
     "    # Update the risk given any positions that have been put on so far in the current step\n",
-    "    bt.algos.UpdateRisk( 'pvbp', unit_risk = pd.concat( [ govt_pvbp, corp_pvbp] ,axis=1)/100., history=True),\n",
-    "    bt.algos.UpdateRisk( 'beta', unit_risk = corp_betas * corp_pvbp / 100., history=True),  \n",
+    "    bt.algos.UpdateRisk( 'pvbp', unit_risk = pd.concat( [ govt_pvbp, corp_pvbp] ,axis=1)/100., history=1),\n",
+    "    bt.algos.UpdateRisk( 'beta', unit_risk = corp_betas * corp_pvbp / 100., history=1),  \n",
     ")\n",
     "hedging_stack = bt.AlgoStack(\n",
     "    # Specify how frequently to hedge risk\n",
@@ -371,7 +371,7 @@
     "    # Hedge out the pvbp risk using the selected government bond\n",
     "    bt.algos.HedgeRisks( ['pvbp']),\n",
     "    # Need to update risk again after hedging so that it gets recorded correctly (post-hedges)\n",
-    "    bt.algos.UpdateRisk( 'pvbp', unit_risk = pd.concat( [ govt_pvbp, corp_pvbp] ,axis=1)/100., history=True),        \n",
+    "    bt.algos.UpdateRisk( 'pvbp', unit_risk = pd.concat( [ govt_pvbp, corp_pvbp] ,axis=1)/100., history=1),        \n",
     ")\n",
     "debug_stack = bt.core.AlgoStack(\n",
     "    # Specify how frequently to display debug info\n",
@@ -627,8 +627,8 @@
    ],
    "source": [
     "# Total bid/offer paid (same for both strategies)\n",
-    "pd.DataFrame( {'base_pvbp':base_test.strategy.bidoffer_paid, \n",
-    "               'hedged_pvbp':hedge_test.strategy.bidoffer_paid }).cumsum().dropna().plot()"
+    "pd.DataFrame( {'base_pvbp':base_test.strategy.bidoffers_paid, \n",
+    "               'hedged_pvbp':hedge_test.strategy.bidoffers_paid }).cumsum().dropna().plot()"
    ]
   },
   {
@@ -790,8 +790,8 @@
     "    bt.algos.Or( [bt.algos.RunWeekly(), \n",
     "                  bt.algos.RunMonthly()] ),\n",
     "    # Update the risk given any positions that have been put on so far in the current step\n",
-    "    bt.algos.UpdateRisk( 'pvbp', unit_risk = pd.concat( [ govt_pvbp, corp_pvbp] ,axis=1)/100., history=True),\n",
-    "    bt.algos.UpdateRisk( 'beta', unit_risk = corp_betas * corp_pvbp / 100., history=True),  \n",
+    "    bt.algos.UpdateRisk( 'pvbp', unit_risk = pd.concat( [ govt_pvbp, corp_pvbp] ,axis=1)/100., history=2),\n",
+    "    bt.algos.UpdateRisk( 'beta', unit_risk = corp_betas * corp_pvbp / 100., history=2),  \n",
     ")\n",
     "hedging_stack = bt.AlgoStack(\n",
     "    # Close any matured hedge positions (including hedges)\n",
@@ -807,7 +807,7 @@
     "    # Hedge out the pvbp risk using the selected government bond\n",
     "    bt.algos.HedgeRisks( ['pvbp']),\n",
     "    # Need to update risk again after hedging so that it gets recorded correctly (post-hedges)\n",
-    "    bt.algos.UpdateRisk( 'pvbp', unit_risk = pd.concat( [ govt_pvbp, corp_pvbp] ,axis=1)/100., history=True),        \n",
+    "    bt.algos.UpdateRisk( 'pvbp', unit_risk = pd.concat( [ govt_pvbp, corp_pvbp] ,axis=1)/100., history=2),        \n",
     ")\n",
     "debug_stack = bt.core.AlgoStack(\n",
     "    # Specify how frequently to display debug info\n",

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -8,17 +8,35 @@ import cProfile
 
 
 def benchmark_1():
-    x = np.random.randn(10000, 100) * 0.01
+    x = np.random.randn(10000, 1000) * 0.01
     idx = pd.date_range('1990-01-01', freq='B', periods=x.shape[0])
     data = np.exp(pd.DataFrame(x, index=idx).cumsum())
 
     s = bt.Strategy('s', [bt.algos.RunMonthly(),
-                          bt.algos.SelectAll(),
                           bt.algos.SelectRandomly(len(data.columns) / 2),
                           bt.algos.WeighRandomly(),
                           bt.algos.Rebalance()])
 
     t = bt.Backtest(s, data)
+    return bt.run(t)
+    
+def benchmark_2():
+    x = np.random.randn(10000, 1000) * 0.01
+    idx = pd.date_range('1990-01-01', freq='B', periods=x.shape[0])
+    data = np.exp(pd.DataFrame(x, index=idx).cumsum())
+    bidoffer = data * 0.01
+    coupons = data * 0.
+    s = bt.FixedIncomeStrategy('s', 
+                            algos = [bt.algos.RunMonthly(),
+                              bt.algos.SelectRandomly(len(data.columns) / 2),
+                              bt.algos.WeighRandomly(),
+                              bt.algos.Rebalance()],
+                              children = [ bt.CouponPayingSecurity(c) 
+                                            for c in data ]
+                              )
+
+    t = bt.Backtest(s, data, additional_data = {'bidoffer':bidoffer, 
+                                                'coupons':coupons})
     return bt.run(t)
 
 
@@ -26,3 +44,7 @@ if __name__ == '__main__':
     print('\n\n\n================= Benchmark 1 =======================\n')
     cProfile.run('benchmark_1()', sort='tottime')
     print('\n----------------- Benchmark 1 -----------------------\n\n\n')
+    
+    print('\n\n\n================= Benchmark 2 =======================\n')
+    cProfile.run('benchmark_2()', sort='tottime')
+    print('\n----------------- Benchmark 2 -----------------------\n\n\n')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2595,19 +2595,26 @@ def test_bidoffer():
 
     # Do some transactions, and check that bidoffer_paid is updated
     c1.transact(100)
-    assert c1.bidoffer_paid[0] == 100 * 1
+    assert c1.bidoffer_paid == 100 * 1
+    assert c1.bidoffers_paid[i] == c1.bidoffer_paid
     c1.transact(100)
-    assert c1.bidoffer_paid[0] == 200 * 1
+    assert c1.bidoffer_paid == 200 * 1
+    assert c1.bidoffers_paid[i] == c1.bidoffer_paid
 
     c2.transact(-100)
-    assert c2.bidoffer_paid[0] == 100 * 0.75
-    assert s.bidoffer_paid[0] == 100 * 0.75 + 200 * 1
+    assert c2.bidoffer_paid == 100 * 0.75
+    assert c2.bidoffers_paid[i] == c2.bidoffer_paid
+    assert s.bidoffer_paid == 100 * 0.75 + 200 * 1
+    assert s.bidoffers_paid[i] == s.bidoffer_paid
 
     i = 1
     s.update(dts[i])
-    assert c1.bidoffer_paid[i] == 0.
-    assert c2.bidoffer_paid[i] == 0.
-    assert s.bidoffer_paid[i] == 0.
+    assert c1.bidoffer_paid == 0.
+    assert c1.bidoffers_paid[i] == c1.bidoffer_paid
+    assert c2.bidoffer_paid == 0.
+    assert c2.bidoffers_paid[i] == c2.bidoffer_paid
+    assert s.bidoffer_paid == 0.
+    assert s.bidoffers_paid[i] == s.bidoffer_paid
 
 
 def test_outlay_custom():
@@ -2663,17 +2670,25 @@ def test_bidoffer_custom():
     s.update(dts[i])
 
     c1.transact(100, price=106)
-    assert c1.bidoffer_paid[0] == 100 * 1
-    assert s.bidoffer_paid[0] == c1.bidoffer_paid[0]
+    assert c1.bidoffer_paid == 100 * 1
+    assert s.bidoffer_paid == c1.bidoffer_paid
     assert s.capital == 100000 - 100*106
+    assert c1.bidoffers_paid[i] == c1.bidoffer_paid
+    assert s.bidoffers_paid[i] == s.bidoffer_paid
+
     c1.transact(100, price=106)
-    assert c1.bidoffer_paid[0] == 200 * 1
-    assert s.bidoffer_paid[0] == c1.bidoffer_paid[0]
+    assert c1.bidoffer_paid == 200 * 1
+    assert s.bidoffer_paid == c1.bidoffer_paid
     assert s.capital == 100000 - 100*106 - 100*106
+    assert c1.bidoffers_paid[i] == c1.bidoffer_paid
+    assert s.bidoffers_paid[i] == s.bidoffer_paid
+
     c1.transact(-100, price=107)
-    assert c1.bidoffer_paid[0] == 0
-    assert s.bidoffer_paid[0] == c1.bidoffer_paid[0]
+    assert c1.bidoffer_paid == 0
+    assert s.bidoffer_paid == c1.bidoffer_paid
     assert s.capital == 100000 - 100*106 - 100*106 + 100*107
+    assert c1.bidoffers_paid[i] == c1.bidoffer_paid
+    assert s.bidoffers_paid[i] == s.bidoffer_paid
 
 
 def test_security_notional_value():
@@ -3311,29 +3326,34 @@ def test_fi_strategy_bidoffer():
     s.update(dts[i])
     assert s.value == 0.
     assert s.price == 100.
-    
+
     # Do some transactions, and check that bidoffer_paid is updated
     c1.transact(100)
-    assert c1.bidoffer_paid[i] == 100 * 1
+    assert c1.bidoffer_paid == 100 * 1
+    assert c1.bidoffers_paid[i] == c1.bidoffer_paid
     c1.transact(100)
-    assert c1.bidoffer_paid[i] == 200 * 1
+    assert c1.bidoffer_paid == 200 * 1
+    assert c1.bidoffers_paid[i] == c1.bidoffer_paid
 
     c2.transact(-100)
-    assert c2.bidoffer_paid[i] == 100 * 0.75
+    assert c2.bidoffer_paid == 100 * 0.75
+    assert c2.bidoffers_paid[i] == c2.bidoffer_paid
 
     s.update(dts[i])
-    assert s.bidoffer_paid[i] == 275.
-    assert s.value == -275. 
+    assert s.bidoffer_paid == 275.
+    assert s.bidoffers_paid[i] == s.bidoffer_paid
+    assert s.value == -275.
     assert s.notional_value == 105*200 + 95*100
-    assert s.price == 100 * (1. - 275. / (105*200 + 95*100))        
-    
+    assert s.price == 100 * (1. - 275. / (105*200 + 95*100))
+
     old_notional = s.notional_value
     old_value = s.value
     old_price = s.price
 
     i=1
     s.update(dts[i])
-    assert s.bidoffer_paid[i] == 0.
+    assert s.bidoffer_paid == 0.
+    assert s.bidoffers_paid[i] == s.bidoffer_paid
     assert s.value == -275. - 200*5 - 100*5 # Bid-offer paid
     assert s.notional_value == 100*200 + 100*100
     new_value = s.value


### PR DESCRIPTION
1. Differentiate bidoffer_paid (float) from bidoffers_paid on Node interface for performance reasons (so that current step value is quickly accessible). As part of this, some rationalization of which private attributes appear on which classes.
2. Improve implementations of ClosePositionsAfterDates and RollPositionsAfterDates for performance
3. Add control over depth of risk calculation, to improve performance in the case when only strategy-level history is required
4. Improve existing benchmark test by removing call to SelectAll (as SelectRandom does this under the hood). This makes the original test faster, so increased the number of assets updated tenfold to highlight any core speed issues.
5. Added a new benchmark test for FixedIncomeStrategy with bidoffer and coupons (which would have caught some of the performance issues fixed in this commit)

All unit tests pass, benchmark tests shows similar performance between the two cases, and the fixed_income notebook also ran much faster.

CC @ptomecek