### PR TITLE
Fix random benchmarking

### DIFF
--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -63,7 +63,7 @@ def benchmark_random(backtest, random_strategy, nsim=100):
 
     bts = []
     bts.append(backtest)
-    data = backtest.data
+    data = backtest.data.dropna()
 
     # create and run random backtests
     for i in range(nsim):


### PR DESCRIPTION
Thanks for such an amazing library!

Small fix here for the random benchmarking. A new instance of Backtest will [add a virtual row at t0-1day](https://github.com/pmorissette/bt/blob/master/bt/backtest.py#L163-L179) tough the backtest.data has already been concatenated with such a row previously, we should remove it when initiating the following random backtests.

Cheers