### PR TITLE
Fixed strategies considering all tickers as universe when only strategy children are specified, and strategy use a subset of tickers

### DIFF
--- a/bt/core.py
+++ b/bt/core.py
@@ -85,8 +85,9 @@ class Node(object):
         self._lazy_children = {}
         self._universe_tickers = []
         self._childrenv = []  # Shortcut to self.children.values()
-        self._original_children_are_present = (children is not None) and\
-                                              (len(children) >= 1)  
+        self._original_children_are_present = (children is not None) and (
+            len(children) >= 1
+        )
 
         # strategy children helpers
         self._has_strat_children = False
@@ -179,7 +180,7 @@ class Node(object):
 
                     self.children[c.name] = c
                     self._childrenv.append(c)
-                    
+
                 # if strategy, turn on flag and add name to list
                 # strategy children have special treatment
                 if isinstance(c, StrategyBase):
@@ -587,7 +588,7 @@ class StrategyBase(Node):
 
         # filter only if the node has any children specified as input,
         # otherwise we use the full universe. If all children are strategies,
-        # funiverse will be empty, to signal that no other ticker should be 
+        # funiverse will be empty, to signal that no other ticker should be
         # used in addition to the strategies
         if self._original_children_are_present:
             # if we have universe_tickers defined, limit universe to
@@ -603,7 +604,7 @@ class StrategyBase(Node):
             if self._has_strat_children:
                 for c in self._strat_children:
                     funiverse[c] = np.nan
-                    
+
             # must create to avoid pandas warning
             funiverse = pd.DataFrame(funiverse)
 

--- a/bt/core.py
+++ b/bt/core.py
@@ -142,10 +142,6 @@ class Node(object):
         """
         # if at least 1 children is specified
         if children is not None:
-            # initialize the universe tickers list, 
-            # which also identifies that we might have to filter the universe
-            if self._universe_tickers is None:
-                self._universe_tickers = []
             if isinstance(children, dict):
                 # Preserve the names from the dictionary by renaming the nodes
                 tmp = []


### PR DESCRIPTION
In the example below, we have a strategy that allocates everything into `spy` (`spy_strategy`) and another strategy (`parent_strategy`) that has `spy_strategy` as its only child. I would expect both strategies to return the same result, as in the second strategy I'm manually specifying the children. 
In practice, `parent_strategy` considers all the other tickers anyway, and treats `spy_strategy` as "one more child". I don't believe this behavior is intended, as it's highly counter-intuitive and I could not find it documented anywhere (sorry if I missed it!)

```
data = ffn.get('agg,hyg,spy,eem,efa', start='2010-01-01', end='2014-01-01') 
spy_strategy = bt.Strategy("spy_strategy", [bt.algos.RunOnce(),  
                                         bt.algos.SelectAll(),
                                         bt.algos.WeighEqually(),
                                         bt.algos.Rebalance()], ["spy"])
parent_strategy = bt.Strategy("parent_strategy", [bt.algos.RunOnce(),  
                                                  bt.algos.SelectAll(),
                                                  bt.algos.WeighEqually(),
                                                  bt.algos.Rebalance()], [spy_strategy])
test1 = bt.Backtest(spy_strategy, data)
test2 = bt.Backtest(parent_strategy, data)
result = bt.run(test1, test2)
result.plot()
```

The fix I proposed is to track whether any child is actually passed to the Node. If so, the universe of tickers should be filtered in `StrategyBase.setup()` even if `self._universe_tickers` is an empty list (which happens if the list of children does not contain any ticker specified as string)