### PR TITLE
Allow different target volatilities for each asset

### DIFF
--- a/bt/algos.py
+++ b/bt/algos.py
@@ -1538,13 +1538,17 @@ class TargetVol(Algo):
             np.matmul(weights.values.T, np.matmul(covar.values, weights.values))
             * self.annualization_factor
         )
-        
+
         if isinstance(self.target_volatility, (float, int)):
-            self.target_volatility = {k : self.target_volatility for k in target.temp["weights"].keys()}
+            self.target_volatility = {
+                k: self.target_volatility for k in target.temp["weights"].keys()
+            }
 
         for k in target.temp["weights"].keys():
             if k in self.target_volatility.keys():
-                target.temp["weights"][k] = target.temp["weights"][k] * self.target_volatility[k] / vol
+                target.temp["weights"][k] = (
+                    target.temp["weights"][k] * self.target_volatility[k] / vol
+                )
 
         return True
 

--- a/bt/algos.py
+++ b/bt/algos.py
@@ -1538,18 +1538,13 @@ class TargetVol(Algo):
             np.matmul(weights.values.T, np.matmul(covar.values, weights.values))
             * self.annualization_factor
         )
-
-        # vol is too high
-        if vol > self.target_volatility:
-            mult = self.target_volatility / vol
-        # vol is too low
-        elif vol < self.target_volatility:
-            mult = self.target_volatility / vol
-        else:
-            mult = 1
+        
+        if isinstance(self.target_volatility, (float, int)):
+            self.target_volatility = {k : self.target_volatility for k in target.temp["weights"].keys()}
 
         for k in target.temp["weights"].keys():
-            target.temp["weights"][k] = target.temp["weights"][k] * mult
+            if k in self.target_volatility.keys():
+                target.temp["weights"][k] = target.temp["weights"][k] * self.target_volatility[k] / vol
 
         return True
 


### PR DESCRIPTION
This change allows different target volatilities for each asset, by passing a dict of values instead of a single one.

Fixes #307

MWE:

```python
import bt

data = bt.get(["spy", "qqq", "gld"])

vol_target_dict = {
    "spy": 0.07,
    "qqq": 0.05,
    "gld": 0.03,
}

s = bt.Strategy('s', [bt.algos.RunMonthly(),
                      bt.algos.SelectAll(),
                      bt.algos.WeighInvVol(),
                      bt.algos.TargetVol(vol_target_dict),
                      bt.algos.Rebalance()])

b = bt.Backtest(s, data)
res = bt.run(b)
res.display()
res.plot()
res.plot_security_weights('s')
```