### PR TITLE
To access a value by position, use ser.iloc[pos]

### DIFF
--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -2076,17 +2076,17 @@ def test_update_risk_history_1():
 
     s.update(dts[0])
     assert algo(s)
-    assert s.risks["Test"][0] == 0
+    assert s.risks["Test"].iloc[0] == 0
 
     s.transact(1, "c1")
     s.transact(5, "c2")
     assert algo(s)
-    assert s.risks["Test"][0] == 600
+    assert s.risks["Test"].iloc[0] == 600
 
     s.update(dts[1])
     assert algo(s)
-    assert s.risks["Test"][0] == 600
-    assert s.risks["Test"][1] == 105 + 5 * 95
+    assert s.risks["Test"].iloc[0] == 600
+    assert s.risks["Test"].iloc[1] == 105 + 5 * 95
 
     assert not hasattr(c1, "risks")
     assert not hasattr(c2, "risks")
@@ -2110,25 +2110,25 @@ def test_update_risk_history_2():
 
     s.update(dts[0])
     assert algo(s)
-    assert s.risks["Test"][0] == 0
-    assert c1.risks["Test"][0] == 0
-    assert c2.risks["Test"][0] == 0
+    assert s.risks["Test"].iloc[0] == 0
+    assert c1.risks["Test"].iloc[0] == 0
+    assert c2.risks["Test"].iloc[0] == 0
 
     s.transact(1, "c1")
     s.transact(5, "c2")
     assert algo(s)
-    assert s.risks["Test"][0] == 600
-    assert c1.risks["Test"][0] == 100
-    assert c2.risks["Test"][0] == 500
+    assert s.risks["Test"].iloc[0] == 600
+    assert c1.risks["Test"].iloc[0] == 100
+    assert c2.risks["Test"].iloc[0] == 500
 
     s.update(dts[1])
     assert algo(s)
-    assert s.risks["Test"][0] == 600
-    assert c1.risks["Test"][0] == 100
-    assert c2.risks["Test"][0] == 500
-    assert s.risks["Test"][1] == 105 + 5 * 95
-    assert c1.risks["Test"][1] == 105
-    assert c2.risks["Test"][1] == 5 * 95
+    assert s.risks["Test"].iloc[0] == 600
+    assert c1.risks["Test"].iloc[0] == 100
+    assert c2.risks["Test"].iloc[0] == 500
+    assert s.risks["Test"].iloc[1] == 105 + 5 * 95
+    assert c1.risks["Test"].iloc[1] == 105
+    assert c2.risks["Test"].iloc[1] == 5 * 95
 
 
 def test_hedge_risk():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -235,11 +235,11 @@ def test_security_setup_prices():
 
     assert c1.price == 105
     assert len(c1.prices) == 1
-    assert c1.prices[0] == 105
+    assert c1.prices.iloc[0] == 105
 
     assert c2.price == 95
     assert len(c2.prices) == 1
-    assert c2.prices[0] == 95
+    assert c2.prices.iloc[0] == 95
 
     # now with setup
     c1 = SecurityBase("c1")
@@ -260,11 +260,11 @@ def test_security_setup_prices():
 
     assert c1.price == 105
     assert len(c1.prices) == 1
-    assert c1.prices[0] == 105
+    assert c1.prices.iloc[0] == 105
 
     assert c2.price == 95
     assert len(c2.prices) == 1
-    assert c2.prices[0] == 95
+    assert c2.prices.iloc[0] == 95
 
 
 def test_strategybase_tree_setup():
@@ -1517,8 +1517,8 @@ def test_strategybase_prices():
         s.update(dts[i])
 
     assert len(s.prices) == 21
-    assert s.prices[-1] == pytest.approx(95.02396, 5)
-    assert s.prices[-2] == pytest.approx(98.67306, 5)
+    assert s.prices.iloc[-1] == pytest.approx(95.02396, 5)
+    assert s.prices.iloc[-2] == pytest.approx(98.67306, 5)
 
 
 def test_fail_if_root_value_negative():
@@ -2747,24 +2747,24 @@ def test_securitybase_transact():
     assert np.isclose(c1.value, amount, rtol=0.0)
     assert np.isclose(c1.weight, amount / original_capital, rtol=0.0)
     assert c1.position == q
-    assert np.isclose(c1.outlays[0], amount, rtol=0.0)
+    assert np.isclose(c1.outlays.iloc[0], amount, rtol=0.0)
 
     assert np.isclose(s.capital, (original_capital - amount))
     assert s.weight == 1
     assert s.value == original_capital
-    assert np.isclose(s.outlays[c1.name][0], amount, rtol=0.0)
+    assert np.isclose(s.outlays[c1.name].iloc[0], amount, rtol=0.0)
 
     # Call again on the same step (and again) to make sure all updates are working
     c1.transact(q)
     c1.transact(q)
     assert c1.position == 3 * q
-    assert np.isclose(c1.outlays[0], 3 * amount, rtol=0.0)
+    assert np.isclose(c1.outlays.iloc[0], 3 * amount, rtol=0.0)
     assert np.isclose(c1.value, 3 * amount, rtol=0.0)
 
     assert np.isclose(s.capital, (original_capital - 3 * amount))
     assert s.weight == 1
     assert s.value == original_capital
-    assert np.isclose(s.outlays[c1.name][0], 3 * amount, rtol=0.0)
+    assert np.isclose(s.outlays[c1.name].iloc[0], 3 * amount, rtol=0.0)
 
 
 def test_security_setup_positions():
@@ -2785,11 +2785,11 @@ def test_security_setup_positions():
 
     assert c1.position == 0
     assert len(c1.positions) == 1
-    assert c1.positions[0] == 0
+    assert c1.positions.iloc[0] == 0
 
     assert c2.position == 0
     assert len(c2.positions) == 1
-    assert c2.positions[0] == 0
+    assert c2.positions.iloc[0] == 0
 
 
 def test_couponpayingsecurity_setup():
@@ -2815,20 +2815,20 @@ def test_couponpayingsecurity_setup():
     assert "coupon" in c1.data
     assert c1.coupon == 0.0
     assert len(c1.coupons) == 1
-    assert c1.coupons[0] == 0.0
+    assert c1.coupons.iloc[0] == 0.0
 
     assert "holding_cost" in c1.data
     assert c1.holding_cost == 0.0
     assert len(c1.holding_costs) == 1
-    assert c1.holding_costs[0] == 0.0
+    assert c1.holding_costs.iloc[0] == 0.0
 
     assert c1.price == 105
     assert len(c1.prices) == 1
-    assert c1.prices[0] == 105
+    assert c1.prices.iloc[0] == 105
 
     assert c2.price == 95
     assert len(c2.prices) == 1
-    assert c2.prices[0] == 95
+    assert c2.prices.iloc[0] == 95
 
 
 def test_couponpayingsecurity_setup_costs():
@@ -2856,20 +2856,20 @@ def test_couponpayingsecurity_setup_costs():
     assert "coupon" in c1.data
     assert c1.coupon == 0.0
     assert len(c1.coupons) == 1
-    assert c1.coupons[0] == 0.0
+    assert c1.coupons.iloc[0] == 0.0
 
     assert "holding_cost" in c1.data
     assert c1.holding_cost == 0.0
     assert len(c1.holding_costs) == 1
-    assert c1.holding_costs[0] == 0.0
+    assert c1.holding_costs.iloc[0] == 0.0
 
     assert c1.price == 105
     assert len(c1.prices) == 1
-    assert c1.prices[0] == 105
+    assert c1.prices.iloc[0] == 105
 
     assert c2.price == 95
     assert len(c2.prices) == 1
-    assert c2.prices[0] == 95
+    assert c2.prices.iloc[0] == 95
 
 
 def test_couponpayingsecurity_carry():
@@ -2901,13 +2901,13 @@ def test_couponpayingsecurity_carry():
 
     assert c1.coupon == 100.0
     assert len(c1.coupons) == 1
-    assert c1.coupons[0] == 100.0
+    assert c1.coupons.iloc[0] == 100.0
     assert c1.holding_cost == 10.0
     assert len(c1.holding_costs) == 1
-    assert c1.holding_costs[0] == 10.0
+    assert c1.holding_costs.iloc[0] == 10.0
 
     assert s.capital == 0.0
-    assert s.cash[0] == 0.0
+    assert s.cash.iloc[0] == 0.0
 
     # On this step, the coupon/costs will be accounted for from the last holding
     i = 1
@@ -2915,21 +2915,21 @@ def test_couponpayingsecurity_carry():
 
     assert c1.coupon == 0.0
     assert len(c1.coupons) == 2
-    assert c1.coupons[1] == 0.0
+    assert c1.coupons.iloc[1] == 0.0
     assert c1.holding_cost == 0.0
     assert len(c1.holding_costs) == 2
-    assert c1.holding_costs[1] == 0.0
+    assert c1.holding_costs.iloc[1] == 0.0
 
     assert s.capital == 100.0 - 10.0
-    assert s.cash[0] == 0.0
-    assert s.cash[1] == 100.0 - 10.0
+    assert s.cash.iloc[0] == 0.0
+    assert s.cash.iloc[1] == 100.0 - 10.0
 
     # Go short q
     c1.transact(-2 * q)
     # Note cost is positive even though we are short.
     assert c1.holding_cost == 50.0
     assert len(c1.holding_costs) == 2
-    assert c1.holding_costs[1] == 50.0
+    assert c1.holding_costs.iloc[1] == 50.0
 
 
 def test_couponpayingsecurity_transact():
@@ -2965,14 +2965,14 @@ def test_couponpayingsecurity_transact():
     # The coupon is nonzero, but will only be counted in "value" the next day
     assert c1.coupon == coupon * q
     assert len(c1.coupons) == 1
-    assert c1.coupons[0] == coupon * q
+    assert c1.coupons.iloc[0] == coupon * q
 
     assert np.isclose(c1.value, amount, rtol=0.0)
     assert np.isclose(c1.weight, amount / original_capital, rtol=0.0)
     assert c1.position == q
 
     assert s.capital == (original_capital - amount)
-    assert s.cash[0] == (original_capital - amount)
+    assert s.cash.iloc[0] == (original_capital - amount)
     assert s.weight == 1
     assert s.value == original_capital
 
@@ -2984,8 +2984,8 @@ def test_couponpayingsecurity_transact():
     new_capital = original_capital + coupon * q
     assert c1.coupon == 0
     assert len(c1.coupons) == 2
-    assert c1.coupons[0] == coupon * q
-    assert c1.coupons[1] == 0
+    assert c1.coupons.iloc[0] == coupon * q
+    assert c1.coupons.iloc[1] == 0
 
     assert np.isclose(c1.value, amount, rtol=0.0)
     assert np.isclose(c1.weight, amount / new_capital, rtol=0.0)
@@ -2994,8 +2994,8 @@ def test_couponpayingsecurity_transact():
     assert s.capital == (new_capital - amount)
     assert s.weight == 1
     assert s.value == new_capital
-    assert s.cash[0] == (original_capital - amount)
-    assert s.cash[1] == (new_capital - amount)
+    assert s.cash.iloc[0] == (original_capital - amount)
+    assert s.cash.iloc[1] == (new_capital - amount)
 
     assert c1._capital == 0
 
@@ -3004,8 +3004,8 @@ def test_couponpayingsecurity_transact():
 
     assert c1.coupon == 0
     assert len(c1.coupons) == 2
-    assert c1.coupons[0] == coupon * q
-    assert c1.coupons[1] == 0
+    assert c1.coupons.iloc[0] == coupon * q
+    assert c1.coupons.iloc[1] == 0
 
     assert np.isclose(c1.value, 0.0, rtol=0.0)
     assert np.isclose(c1.weight, 0.0 / new_capital, rtol=0.0)
@@ -3014,8 +3014,8 @@ def test_couponpayingsecurity_transact():
     assert s.capital == new_capital
     assert s.weight == 1
     assert s.value == new_capital
-    assert s.cash[0] == (original_capital - amount)
-    assert s.cash[1] == new_capital
+    assert s.cash.iloc[0] == (original_capital - amount)
+    assert s.cash.iloc[1] == new_capital
 
     assert c1._capital == 0
 
@@ -3044,11 +3044,11 @@ def test_bidoffer():
 
     assert c1.bidoffer == 2
     assert len(c1.bidoffers) == 1
-    assert c1.bidoffers[0] == 2
+    assert c1.bidoffers.iloc[0] == 2
 
     assert c2.bidoffer == 1.5
     assert len(c2.bidoffers) == 1
-    assert c2.bidoffers[0] == 1.5
+    assert c2.bidoffers.iloc[0] == 1.5
 
     # Check the outlays are adjusted for bid/offer
     s.set_commissions(lambda q, p: 0.1)
@@ -3080,28 +3080,28 @@ def test_bidoffer():
     # Do some transactions, and check that bidoffer_paid is updated
     c1.transact(100)
     assert c1.bidoffer_paid == 100 * 1
-    assert c1.bidoffers_paid[i] == c1.bidoffer_paid
+    assert c1.bidoffers_paid.iloc[i] == c1.bidoffer_paid
     c1.transact(100)
     assert c1.bidoffer_paid == 200 * 1
-    assert c1.bidoffers_paid[i] == c1.bidoffer_paid
+    assert c1.bidoffers_paid.iloc[i] == c1.bidoffer_paid
 
     c2.transact(-100)
     assert c2.bidoffer_paid == 100 * 0.75
-    assert c2.bidoffers_paid[i] == c2.bidoffer_paid
+    assert c2.bidoffers_paid.iloc[i] == c2.bidoffer_paid
     assert s.bidoffer_paid == 100 * 0.75 + 200 * 1
-    assert s.bidoffers_paid[i] == s.bidoffer_paid
+    assert s.bidoffers_paid.iloc[i] == s.bidoffer_paid
 
     assert s.fees.iloc[i] == 3 * 0.1
 
     i = 1
     s.update(dts[i])
     assert c1.bidoffer_paid == 0.0
-    assert c1.bidoffers_paid[i] == c1.bidoffer_paid
+    assert c1.bidoffers_paid.iloc[i] == c1.bidoffer_paid
     assert c2.bidoffer_paid == 0.0
-    assert c2.bidoffers_paid[i] == c2.bidoffer_paid
+    assert c2.bidoffers_paid.iloc[i] == c2.bidoffer_paid
     assert s.bidoffer_paid == 0.0
-    assert s.bidoffers_paid[i] == s.bidoffer_paid
-    assert s.fees[i] == 0.0
+    assert s.bidoffers_paid.iloc[i] == s.bidoffer_paid
+    assert s.fees.iloc[i] == 0.0
 
 
 def test_outlay_custom():
@@ -3160,22 +3160,22 @@ def test_bidoffer_custom():
     assert c1.bidoffer_paid == 100 * 1
     assert s.bidoffer_paid == c1.bidoffer_paid
     assert s.capital == 100000 - 100 * 106
-    assert c1.bidoffers_paid[i] == c1.bidoffer_paid
-    assert s.bidoffers_paid[i] == s.bidoffer_paid
+    assert c1.bidoffers_paid.iloc[i] == c1.bidoffer_paid
+    assert s.bidoffers_paid.iloc[i] == s.bidoffer_paid
 
     c1.transact(100, price=106)
     assert c1.bidoffer_paid == 200 * 1
     assert s.bidoffer_paid == c1.bidoffer_paid
     assert s.capital == 100000 - 100 * 106 - 100 * 106
-    assert c1.bidoffers_paid[i] == c1.bidoffer_paid
-    assert s.bidoffers_paid[i] == s.bidoffer_paid
+    assert c1.bidoffers_paid.iloc[i] == c1.bidoffer_paid
+    assert s.bidoffers_paid.iloc[i] == s.bidoffer_paid
 
     c1.transact(-100, price=107)
     assert c1.bidoffer_paid == 0
     assert s.bidoffer_paid == c1.bidoffer_paid
     assert s.capital == 100000 - 100 * 106 - 100 * 106 + 100 * 107
-    assert c1.bidoffers_paid[i] == c1.bidoffer_paid
-    assert s.bidoffers_paid[i] == s.bidoffer_paid
+    assert c1.bidoffers_paid.iloc[i] == c1.bidoffer_paid
+    assert s.bidoffers_paid.iloc[i] == s.bidoffer_paid
 
 
 def test_security_notional_value():
@@ -3839,18 +3839,18 @@ def test_fi_strategy_bidoffer():
     # Do some transactions, and check that bidoffer_paid is updated
     c1.transact(100)
     assert c1.bidoffer_paid == 100 * 1
-    assert c1.bidoffers_paid[i] == c1.bidoffer_paid
+    assert c1.bidoffers_paid.iloc[i] == c1.bidoffer_paid
     c1.transact(100)
     assert c1.bidoffer_paid == 200 * 1
-    assert c1.bidoffers_paid[i] == c1.bidoffer_paid
+    assert c1.bidoffers_paid.iloc[i] == c1.bidoffer_paid
 
     c2.transact(-100)
     assert c2.bidoffer_paid == 100 * 0.75
-    assert c2.bidoffers_paid[i] == c2.bidoffer_paid
+    assert c2.bidoffers_paid.iloc[i] == c2.bidoffer_paid
 
     s.update(dts[i])
     assert s.bidoffer_paid == 275.0
-    assert s.bidoffers_paid[i] == s.bidoffer_paid
+    assert s.bidoffers_paid.iloc[i] == s.bidoffer_paid
     assert s.value == -275.0
     assert s.notional_value == 105 * 200 + 95 * 100
     assert s.price == 100 * (1.0 - 275.0 / (105 * 200 + 95 * 100))
@@ -3862,7 +3862,7 @@ def test_fi_strategy_bidoffer():
     i = 1
     s.update(dts[i])
     assert s.bidoffer_paid == 0.0
-    assert s.bidoffers_paid[i] == s.bidoffer_paid
+    assert s.bidoffers_paid.iloc[i] == s.bidoffer_paid
     assert s.value == -275.0 - 200 * 5 - 100 * 5  # Bid-offer paid
     assert s.notional_value == 100 * 200 + 100 * 100
     new_value = s.value


### PR DESCRIPTION
This PR removes the warnings:

`FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]``