### PR TITLE
Removes chained indexing.

### DIFF
--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -651,9 +651,9 @@ def test_select_all():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100.0)
-    data["c1"][dts[1]] = np.nan
-    data["c2"][dts[1]] = 95
-    data["c1"][dts[2]] = -5
+    data.loc[dts[1], "c1"] = np.nan
+    data.loc[dts[1], "c2"] = 95
+    data.loc[dts[2], "c1"] = -5
 
     s.setup(data)
     s.update(dts[0])
@@ -705,9 +705,9 @@ def test_select_randomly_n_none():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100.0)
-    data["c1"][dts[1]] = np.nan
-    data["c2"][dts[1]] = 95
-    data["c1"][dts[2]] = -5
+    data.loc[dts[1], "c1"] = np.nan
+    data.loc[dts[1], "c2"] = 95
+    data.loc[dts[2], "c1"] = -5
 
     s.setup(data)
     s.update(dts[0])
@@ -758,9 +758,9 @@ def test_select_randomly():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2", "c3"], data=100.0)
-    data["c1"][dts[0]] = np.nan
-    data["c2"][dts[0]] = 95
-    data["c3"][dts[0]] = -5
+    data.loc[dts[0], "c1"] = np.nan
+    data.loc[dts[0], "c2"] = 95
+    data.loc[dts[0], "c3"] = -5
 
     s.setup(data)
     s.update(dts[0])
@@ -792,9 +792,9 @@ def test_select_these():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100.0)
-    data["c1"][dts[1]] = np.nan
-    data["c2"][dts[1]] = 95
-    data["c1"][dts[2]] = -5
+    data.loc[dts[1], "c1"] = np.nan
+    data.loc[dts[1], "c2"] = 95
+    data.loc[dts[2], "c1"] = -5
 
     s.setup(data)
     s.update(dts[0])
@@ -852,9 +852,9 @@ def test_select_where_all():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100.0)
-    data["c1"][dts[1]] = np.nan
-    data["c2"][dts[1]] = 95
-    data["c1"][dts[2]] = -5
+    data.loc[dts[1], "c1"] = np.nan
+    data.loc[dts[1], "c2"] = 95
+    data.loc[dts[2], "c1"] = -5
 
     where = pd.DataFrame(index=dts, columns=["c1", "c2"], data=True)
 
@@ -911,7 +911,7 @@ def test_select_where():
 
     where = pd.DataFrame(index=dts, columns=["c1", "c2"], data=True)
     where.loc[dts[1]] = False
-    where["c1"].loc[dts[2]] = False
+    where.loc[dts[2], "c1"] = False
 
     algo = algos.SelectWhere("where")
 
@@ -941,7 +941,7 @@ def test_select_where_legacy():
 
     where = pd.DataFrame(index=dts, columns=["c1", "c2"], data=True)
     where.loc[dts[1]] = False
-    where["c1"].loc[dts[2]] = False
+    where.loc[dts[2], "c1"] = False
 
     algo = algos.SelectWhere(where)
 
@@ -980,9 +980,9 @@ def test_resolve_on_the_run():
     s = bt.Strategy("s")
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2", "b1"], data=100.0)
-    data["c1"][dts[1]] = np.nan
-    data["c2"][dts[1]] = 95
-    data["c2"][dts[2]] = -5
+    data.loc[dts[1], "c1"] = np.nan
+    data.loc[dts[1], "c2"] = 95
+    data.loc[dts[2], "c2"] = -5
 
     on_the_run = pd.DataFrame(index=dts, columns=["c"], data="c1")
     on_the_run.loc[dts[2], "c"] = "c2"
@@ -1097,8 +1097,8 @@ def test_weight_specified():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[1]] = 105
-    data["c2"][dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     s.setup(data)
     s.update(dts[0])
@@ -1128,8 +1128,8 @@ def test_select_has_data():
 
     dts = pd.date_range("2010-01-01", periods=10)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100.0)
-    data["c1"].loc[dts[0]] = np.nan
-    data["c1"].loc[dts[1]] = np.nan
+    data.loc[dts[0], "c1"] = np.nan
+    data.loc[dts[1], "c1"] = np.nan
 
     s.setup(data)
     s.update(dts[2])
@@ -1147,8 +1147,8 @@ def test_select_has_data_preselected():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100.0)
-    data["c1"].loc[dts[0]] = np.nan
-    data["c1"].loc[dts[1]] = np.nan
+    data.loc[dts[0], "c1"] = np.nan
+    data.loc[dts[1], "c1"] = np.nan
 
     s.setup(data)
     s.update(dts[2])
@@ -1195,8 +1195,8 @@ def test_weigh_target():
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100.0)
     target = pd.DataFrame(index=dts[:2], columns=["c1", "c2"], data=0.5)
-    target["c1"].loc[dts[1]] = 1.0
-    target["c2"].loc[dts[1]] = 0.0
+    target.loc[dts[1], "c1"] = 1.0
+    target.loc[dts[1], "c2"] = 0.0
 
     s.setup(data, target=target)
 
@@ -1227,16 +1227,16 @@ def test_weigh_inv_vol():
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100.0)
 
     # high vol c1
-    data["c1"].loc[dts[1]] = 105
-    data["c1"].loc[dts[2]] = 95
-    data["c1"].loc[dts[3]] = 105
-    data["c1"].loc[dts[4]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[2], "c1"] = 95
+    data.loc[dts[3], "c1"] = 105
+    data.loc[dts[4], "c1"] = 95
 
     # low vol c2
-    data["c2"].loc[dts[1]] = 100.1
-    data["c2"].loc[dts[2]] = 99.9
-    data["c2"].loc[dts[3]] = 100.1
-    data["c2"].loc[dts[4]] = 99.9
+    data.loc[dts[1], "c2"] = 100.1
+    data.loc[dts[2], "c2"] = 99.9
+    data.loc[dts[3], "c2"] = 100.1
+    data.loc[dts[4], "c2"] = 99.9
 
     s.setup(data)
     s.update(dts[4])
@@ -1303,12 +1303,12 @@ def test_set_stat():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100.0)
-    data["c1"].loc[dts[1]] = 105
-    data["c2"].loc[dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     stat = pd.DataFrame(index=dts, columns=["c1", "c2"], data=4.0)
-    stat["c1"].loc[dts[1]] = 5.0
-    stat["c2"].loc[dts[1]] = 6.0
+    stat.loc[dts[1], "c1"] = 5.0
+    stat.loc[dts[1], "c2"] = 6.0
 
     algo = algos.SetStat("test_stat")
 
@@ -1333,12 +1333,12 @@ def test_set_stat_legacy():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100.0)
-    data["c1"].loc[dts[1]] = 105
-    data["c2"].loc[dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     stat = pd.DataFrame(index=dts, columns=["c1", "c2"], data=4.0)
-    stat["c1"].loc[dts[1]] = 5.0
-    stat["c2"].loc[dts[1]] = 6.0
+    stat.loc[dts[1], "c1"] = 5.0
+    stat.loc[dts[1], "c2"] = 6.0
 
     algo = algos.SetStat(stat)
 
@@ -1363,8 +1363,8 @@ def test_stat_total_return():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100.0)
-    data["c1"].loc[dts[2]] = 105
-    data["c2"].loc[dts[2]] = 95
+    data.loc[dts[2], "c1"] = 105
+    data.loc[dts[2], "c2"] = 95
 
     s.setup(data)
     s.update(dts[2])
@@ -1384,8 +1384,8 @@ def test_select_n():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100.0)
-    data["c1"].loc[dts[2]] = 105
-    data["c2"].loc[dts[2]] = 95
+    data.loc[dts[2], "c1"] = 105
+    data.loc[dts[2], "c2"] = 95
 
     s.setup(data)
     s.update(dts[2])
@@ -1424,8 +1424,8 @@ def test_select_n_perc():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100.0)
-    data["c1"].loc[dts[2]] = 105
-    data["c2"].loc[dts[2]] = 95
+    data.loc[dts[2], "c1"] = 105
+    data.loc[dts[2], "c2"] = 95
 
     s.setup(data)
     s.update(dts[2])
@@ -1444,8 +1444,8 @@ def test_select_momentum():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100.0)
-    data["c1"].loc[dts[2]] = 105
-    data["c2"].loc[dts[2]] = 95
+    data.loc[dts[2], "c1"] = 105
+    data.loc[dts[2], "c2"] = 95
 
     s.setup(data)
     s.update(dts[2])
@@ -2024,8 +2024,8 @@ def test_update_risk():
     s = bt.Strategy("s", children=[c1, c2])
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"].loc[dts[1]] = 105
-    data["c2"].loc[dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
     c1 = s["c1"]
     c2 = s["c2"]
 
@@ -2064,8 +2064,8 @@ def test_update_risk_history_1():
     s = bt.Strategy("s", children=[c1, c2])
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"].loc[dts[1]] = 105
-    data["c2"].loc[dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
     c1 = s["c1"]
     c2 = s["c2"]
 
@@ -2098,8 +2098,8 @@ def test_update_risk_history_2():
     s = bt.Strategy("s", children=[c1, c2])
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"].loc[dts[1]] = 105
-    data["c2"].loc[dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
     c1 = s["c1"]
     c2 = s["c2"]
 

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -83,14 +83,14 @@ def test_turnover():
     dts = pd.date_range("2010-01-01", periods=5)
     data = pd.DataFrame(index=dts, columns=["a", "b"], data=100)
 
-    data["a"][dts[1]] = 105
-    data["b"][dts[1]] = 95
+    data.loc[dts[1], "a"] = 105
+    data.loc[dts[1], "b"] = 95
 
-    data["a"][dts[2]] = 110
-    data["b"][dts[2]] = 90
+    data.loc[dts[2], "a"] = 110
+    data.loc[dts[2], "b"] = 90
 
-    data["a"][dts[3]] = 115
-    data["b"][dts[3]] = 85
+    data.loc[dts[3], "a"] = 115
+    data.loc[dts[3], "b"] = 85
 
     s = bt.Strategy(
         "s", [bt.algos.SelectAll(), bt.algos.WeighEqually(), bt.algos.Rebalance()]
@@ -265,18 +265,18 @@ def test_30_min_data():
 def test_RenomalizedFixedIncomeResult():
     dts = pd.date_range("2010-01-01", periods=5)
     data = pd.DataFrame(index=dts, columns=["a"], data=1.0)
-    data["a"][dts[0]] = 0.99
-    data["a"][dts[1]] = 1.01
-    data["a"][dts[2]] = 0.99
-    data["a"][dts[3]] = 1.01
-    data["a"][dts[4]] = 0.99
+    data.loc[dts[0], "a"] = 0.99
+    data.loc[dts[1], "a"] = 1.01
+    data.loc[dts[2], "a"] = 0.99
+    data.loc[dts[3], "a"] = 1.01
+    data.loc[dts[4], "a"] = 0.99
 
     weights = pd.DataFrame(index=dts, columns=["a"], data=1.0)
-    weights["a"][dts[0]] = 1.0
-    weights["a"][dts[1]] = 2.0
-    weights["a"][dts[2]] = 1.0
-    weights["a"][dts[3]] = 2.0
-    weights["a"][dts[4]] = 1.0
+    weights.loc[dts[0], "a"] = 1.0
+    weights.loc[dts[1], "a"] = 2.0
+    weights.loc[dts[2], "a"] = 1.0
+    weights.loc[dts[3], "a"] = 2.0
+    weights.loc[dts[4], "a"] = 1.0
 
     coupons = pd.DataFrame(index=dts, columns=["a"], data=0.0)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -225,8 +225,8 @@ def test_security_setup_prices():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[0]] = 105
-    data["c2"][dts[0]] = 95
+    data.loc[dts[0], "c1"] = 105
+    data.loc[dts[0], "c2"] = 95
 
     s.setup(data)
 
@@ -250,8 +250,8 @@ def test_security_setup_prices():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[0]] = 105
-    data["c2"][dts[0]] = 95
+    data.loc[dts[0], "c1"] = 105
+    data.loc[dts[0], "c2"] = 95
 
     s.setup(data)
 
@@ -277,8 +277,8 @@ def test_strategybase_tree_setup():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[1]] = 105
-    data["c2"][dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     s.setup(data)
 
@@ -302,8 +302,8 @@ def test_strategybase_tree_adjust():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[1]] = 105
-    data["c2"][dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     s.setup(data)
 
@@ -329,8 +329,8 @@ def test_strategybase_tree_update():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[1]] = 105
-    data["c2"][dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     s.setup(data)
 
@@ -358,7 +358,7 @@ def test_update_fails_if_price_is_nan_and_position_open():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1"], data=100)
-    data["c1"][dts[1]] = np.nan
+    data.loc[dts[1], "c1"] = np.nan
 
     c1.setup(data)
 
@@ -396,8 +396,8 @@ def test_strategybase_tree_allocate():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[1]] = 105
-    data["c2"][dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     s.setup(data)
 
@@ -433,8 +433,8 @@ def test_strategybase_tree_allocate_child_from_strategy():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[1]] = 105
-    data["c2"][dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     s.setup(data)
 
@@ -480,8 +480,8 @@ def test_strategybase_tree_allocate_level2():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[1]] = 105
-    data["c2"][dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     m.setup(data)
 
@@ -535,8 +535,8 @@ def test_strategybase_tree_allocate_long_short():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[1]] = 105
-    data["c2"][dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     s.setup(data)
 
@@ -588,8 +588,8 @@ def test_strategybase_tree_allocate_update():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[1]] = 105
-    data["c2"][dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     s.setup(data)
 
@@ -628,8 +628,8 @@ def test_strategybase_universe():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[0]] = 105
-    data["c2"][dts[0]] = 95
+    data.loc[dts[0], "c1"] = 105
+    data.loc[dts[0], "c2"] = 95
 
     s.setup(data)
 
@@ -651,8 +651,8 @@ def test_strategybase_allocate():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[0]] = 100
-    data["c2"][dts[0]] = 95
+    data.loc[dts[0], "c1"] = 100
+    data.loc[dts[0], "c2"] = 95
 
     s.setup(data)
 
@@ -681,8 +681,8 @@ def test_strategybase_lazy():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[0]] = 105
-    data["c2"][dts[0]] = 95
+    data.loc[dts[0], "c1"] = 105
+    data.loc[dts[0], "c2"] = 95
 
     s.setup(data)
 
@@ -769,12 +769,12 @@ def test_strategybase_multiple_calls():
     dts = pd.date_range("2010-01-01", periods=5)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
 
-    data.c2[dts[0]] = 95
-    data.c1[dts[1]] = 95
-    data.c2[dts[2]] = 95
-    data.c2[dts[3]] = 95
-    data.c2[dts[4]] = 95
-    data.c1[dts[4]] = 105
+    data.loc[dts[0], 'c2'] = 95
+    data.loc[dts[1], 'c1'] = 95
+    data.loc[dts[2], 'c2'] = 95
+    data.loc[dts[3], 'c2'] = 95
+    data.loc[dts[4], 'c2'] = 95
+    data.loc[dts[4], 'c1'] = 105
 
     s.setup(data)
 
@@ -1027,12 +1027,12 @@ def test_strategybase_multiple_calls_preset_secs():
     dts = pd.date_range("2010-01-01", periods=5)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
 
-    data.c2[dts[0]] = 95
-    data.c1[dts[1]] = 95
-    data.c2[dts[2]] = 95
-    data.c2[dts[3]] = 95
-    data.c2[dts[4]] = 95
-    data.c1[dts[4]] = 105
+    data.loc[dts[0], 'c2'] = 95
+    data.loc[dts[1], 'c1'] = 95
+    data.loc[dts[2], 'c2'] = 95
+    data.loc[dts[3], 'c2'] = 95
+    data.loc[dts[4], 'c2'] = 95
+    data.loc[dts[4], 'c1'] = 105
 
     s.setup(data)
 
@@ -1275,12 +1275,12 @@ def test_strategybase_multiple_calls_no_post_update():
     dts = pd.date_range("2010-01-01", periods=5)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
 
-    data.c2[dts[0]] = 95
-    data.c1[dts[1]] = 95
-    data.c2[dts[2]] = 95
-    data.c2[dts[3]] = 95
-    data.c2[dts[4]] = 95
-    data.c1[dts[4]] = 105
+    data.loc[dts[0], 'c2'] = 95
+    data.loc[dts[1], 'c1'] = 95
+    data.loc[dts[2], 'c2'] = 95
+    data.loc[dts[3], 'c2'] = 95
+    data.loc[dts[4], 'c2'] = 95
+    data.loc[dts[4], 'c1'] = 105
 
     s.setup(data)
 
@@ -1525,8 +1525,8 @@ def test_fail_if_root_value_negative():
     s = StrategyBase("s")
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[0]] = 100
-    data["c2"][dts[0]] = 95
+    data.loc[dts[0], "c1"] = 100
+    data.loc[dts[0], "c2"] = 95
     s.setup(data)
 
     s.adjust(-100)
@@ -1557,8 +1557,8 @@ def test_fail_if_root_value_negative():
 def test_fail_if_0_base_in_return_calc():
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[0]] = 100
-    data["c2"][dts[0]] = 95
+    data.loc[dts[0], "c1"] = 100
+    data.loc[dts[0], "c2"] = 95
 
     # must setup tree because if not negative root error pops up first
     c1 = StrategyBase("c1")
@@ -1593,8 +1593,8 @@ def test_strategybase_tree_rebalance():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[1]] = 105
-    data["c2"][dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     s.setup(data)
 
@@ -1656,8 +1656,8 @@ def test_rebalance_child_not_in_tree():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[1]] = 105
-    data["c2"][dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     s.setup(data)
 
@@ -1683,8 +1683,8 @@ def test_strategybase_tree_rebalance_to_0():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[1]] = 105
-    data["c2"][dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     s.setup(data)
 
@@ -1739,8 +1739,8 @@ def test_strategybase_tree_rebalance_level2():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[1]] = 105
-    data["c2"][dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     m.setup(data)
 
@@ -1815,8 +1815,8 @@ def test_strategybase_tree_rebalance_base():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[1]] = 105
-    data["c2"][dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     s.setup(data)
 
@@ -2056,8 +2056,8 @@ def test_strategy_tree_proper_universes():
 def test_strategy_tree_paper():
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["a"], data=100.0)
-    data["a"].loc[dts[1]] = 101
-    data["a"].loc[dts[2]] = 102
+    data.loc[dts[1], "a"] = 101
+    data.loc[dts[2], "a"] = 102
 
     s = Strategy(
         "s",
@@ -2105,8 +2105,8 @@ def test_dynamic_strategy():
     parent = Strategy("p", [do_nothing], [])
     dts = pd.date_range("2010-01-01", periods=4)
     data = pd.DataFrame(index=dts, columns=["c1", "c2", "c3"], data=100.0)
-    data["c1"][dts[2]] = 105.0
-    data["c2"][dts[2]] = 95.0
+    data.loc[dts[2], "c1"] = 105.0
+    data.loc[dts[2], "c2"] = 95.0
 
     parent.setup(data)
 
@@ -2176,10 +2176,10 @@ def test_dynamic_strategy2():
 
     dts = pd.date_range("2010-01-01", periods=4)
     data = pd.DataFrame(index=dts, columns=["c1", "c2", "c3"], data=100.0)
-    data["c1"][dts[2]] = 105.0
-    data["c2"][dts[2]] = 95.0
-    data["c1"][dts[3]] = 101.0
-    data["c2"][dts[3]] = 99.0
+    data.loc[dts[2], "c1"] = 105.0
+    data.loc[dts[2], "c2"] = 95.0
+    data.loc[dts[3], "c1"] = 101.0
+    data.loc[dts[3], "c2"] = 99.0
     parent.setup(data)
 
     i = 0
@@ -2271,8 +2271,8 @@ def test_outlays():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[0]] = 105
-    data["c2"][dts[0]] = 95
+    data.loc[dts[0], "c1"] = 105
+    data.loc[dts[0], "c2"] = 95
 
     s.setup(data)
 
@@ -2437,7 +2437,7 @@ def test_securitybase_allocate():
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1"], data=100.0)
     # set the price
-    data["c1"][dts[0]] = 91.40246706608193
+    data.loc[dts[0], "c1"] = 91.40246706608193
     s.setup(data)
 
     i = 0
@@ -2727,7 +2727,7 @@ def test_securitybase_transact():
     data = pd.DataFrame(index=dts, columns=["c1"], data=100.0)
     # set the price
     price = 91.40246706608193
-    data["c1"][dts[0]] = 91.40246706608193
+    data.loc[dts[0], "c1"] = 91.40246706608193
     s.setup(data)
 
     i = 0
@@ -2802,8 +2802,8 @@ def test_couponpayingsecurity_setup():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[0]] = 105
-    data["c2"][dts[0]] = 95
+    data.loc[dts[0], "c1"] = 105
+    data.loc[dts[0], "c2"] = 95
 
     coupons = pd.DataFrame(index=dts, columns=["c1"], data=0.1)
 
@@ -2841,8 +2841,8 @@ def test_couponpayingsecurity_setup_costs():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[0]] = 105
-    data["c2"][dts[0]] = 95
+    data.loc[dts[0], "c1"] = 105
+    data.loc[dts[0], "c2"] = 95
 
     coupons = pd.DataFrame(index=dts, columns=["c1"], data=0.0)
     cost_long = pd.DataFrame(index=dts, columns=["c1"], data=0.01)
@@ -2882,9 +2882,9 @@ def test_couponpayingsecurity_carry():
     data = pd.DataFrame(index=dts, columns=["c1"], data=1.0)
 
     coupons = pd.DataFrame(index=dts, columns=["c1"], data=0.0)
-    coupons["c1"][dts[0]] = 0.1
+    coupons.loc[dts[0], "c1"] = 0.1
     cost_long = pd.DataFrame(index=dts, columns=["c1"], data=0.0)
-    cost_long["c1"][dts[0]] = 0.01
+    cost_long.loc[dts[0], "c1"] = 0.01
     cost_short = pd.DataFrame(index=dts, columns=["c1"], data=0.05)
 
     s.setup(data, coupons=coupons, cost_long=cost_long, cost_short=cost_short)
@@ -2942,12 +2942,12 @@ def test_couponpayingsecurity_transact():
     data = pd.DataFrame(index=dts, columns=["c1"], data=100.0)
     # set the price
     price = 91.40246706608193
-    data["c1"][dts[0]] = 91.40246706608193
-    data["c1"][dts[1]] = 91.40246706608193
+    data.loc[dts[0], "c1"] = 91.40246706608193
+    data.loc[dts[1], "c1"] = 91.40246706608193
 
     coupon = 0.1
     coupons = pd.DataFrame(index=dts, columns=["c1"], data=0.0)
-    coupons["c1"][dts[0]] = coupon
+    coupons.loc[dts[0], "c1"] = coupon
 
     s.setup(data, coupons=coupons)
 
@@ -3030,12 +3030,12 @@ def test_bidoffer():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[0]] = 105
-    data["c2"][dts[0]] = 95
+    data.loc[dts[0], "c1"] = 105
+    data.loc[dts[0], "c2"] = 95
 
     bidoffer = pd.DataFrame(index=dts, columns=["c1", "c2"], data=1.0)
-    bidoffer["c1"][dts[0]] = 2
-    bidoffer["c2"][dts[0]] = 1.5
+    bidoffer.loc[dts[0], "c1"] = 2
+    bidoffer.loc[dts[0], "c2"] = 1.5
 
     s.setup(data, bidoffer=bidoffer)
     s.adjust(100000)
@@ -3114,7 +3114,7 @@ def test_outlay_custom():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[0]] = 105
+    data.loc[dts[0], "c1"] = 105
 
     s.setup(data)
     s.adjust(100000)
@@ -3147,7 +3147,7 @@ def test_bidoffer_custom():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[0]] = 105
+    data.loc[dts[0], "c1"] = 105
 
     # Note: In order to access bidoffer_paid,
     # need to pass bidoffer kwarg during setup
@@ -3265,8 +3265,8 @@ def test_fi_strategy_no_bankruptcy():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[1]] = 105
-    data["c2"][dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     s.setup(data)
 
@@ -3290,8 +3290,8 @@ def test_fi_strategy_tree_adjust():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[1]] = 105
-    data["c2"][dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     s.setup(data)
 
@@ -3323,9 +3323,9 @@ def test_fi_strategy_tree_update():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[1]] = 105
-    data["c2"][dts[1]] = -5  # Test negative prices
-    data["c2"][dts[2]] = 0  # Test zero price
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = -5  # Test negative prices
+    data.loc[dts[2], "c2"] = 0  # Test zero price
 
     s.setup(data)
 
@@ -3358,8 +3358,8 @@ def test_fi_strategy_tree_allocate():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[1]] = 105
-    data["c2"][dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     s.setup(data)
 
@@ -3397,8 +3397,8 @@ def test_fi_strategy_tree_allocate_child_from_strategy():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[1]] = 105
-    data["c2"][dts[1]] = 95
+    data.loc[dts[1], "c1"] = 105
+    data.loc[dts[1], "c2"] = 95
 
     s.setup(data)
 
@@ -3823,12 +3823,12 @@ def test_fi_strategy_bidoffer():
 
     dts = pd.date_range("2010-01-01", periods=3)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)
-    data["c1"][dts[0]] = 105
-    data["c2"][dts[0]] = 95
+    data.loc[dts[0], "c1"] = 105
+    data.loc[dts[0], "c2"] = 95
 
     bidoffer = pd.DataFrame(index=dts, columns=["c1", "c2"], data=1.0)
-    bidoffer["c1"][dts[0]] = 2
-    bidoffer["c2"][dts[0]] = 1.5
+    bidoffer.loc[dts[0], "c1"] = 2
+    bidoffer.loc[dts[0], "c2"] = 1.5
 
     s.setup(data, bidoffer=bidoffer)
     i = 0


### PR DESCRIPTION
This PR removes the warnings:

```
FutureWarning: ChainedAssignmentError: behaviour will change in pandas 3.0!
  You are setting values through chained assignment. Currently this works in certain cases, but when using Copy-on-Write (which will become the default behaviour in pandas 3.0) this will never work to update the original DataFrame or Series, because the intermediate object on which we are setting values will behave as a copy.
  A typical example is when you are setting values in a column of a DataFrame, like:
  
  df["col"][row_indexer] = value
  
  Use `df.loc[row_indexer, "col"] = values` instead, to perform the assignment in a single step and ensure this keeps updating the original `df`.
  
  See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
```