### PR TITLE
Allowing clients to disable the progress bar on run

### DIFF
--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 import bt
 
 
-def run(*backtests):
+def run(*backtests, progress_bar=True):
     """
     Runs a series of backtests and returns a Result
     object containing the results of the backtests.
@@ -27,7 +27,7 @@ def run(*backtests):
 
     """
     # run each backtest
-    for bkt in tqdm(backtests):
+    for bkt in tqdm(backtests, disable=not progress_bar):
         bkt.run()
 
     return Result(*backtests)

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -109,6 +109,34 @@ def test_turnover():
     assert np.allclose(t.turnover[dts[4]], 76100.0 / 1015285)
 
 
+def test_can_disable_progress_bar_from_run():
+    from contextlib import redirect_stderr
+    from io import StringIO
+
+    # Create an in-memory buffer
+    output_capture = StringIO()
+
+    data = pd.DataFrame(
+        index=pd.date_range("2010-01-01", periods=5), columns=["a", "b"], data=100
+    )
+    s = bt.Strategy("test", [
+        bt.algos.SelectAll(),
+        bt.algos.WeighEqually(),
+        bt.algos.Rebalance()
+    ])
+
+    b = bt.Backtest(s, data)
+
+    # Redirect stderr to the buffer
+    with redirect_stderr(output_capture):
+        result = bt.run(b, progress_bar=False)
+
+    # confirm that the output is empty
+    assert output_capture.getvalue() is ""
+    # confirm that we actually ran something
+    assert  len(result.get_transactions()) > 0
+
+
 def test_Results_helper_functions():
 
     names = ["foo", "bar"]


### PR DESCRIPTION
When calling `bt.run` inside a loop the progress bar output can be a noisy. This gives clients the ability to disable that.