### PR TITLE
Fix/futurewarn bool dtype

### DIFF
--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -208,10 +208,12 @@ class Backtest(object):
                     columns=old.columns,
                     index=[old.index[0] - pd.DateOffset(days=1)],
                 )
+                # Ensure dtypes match to avoid FutureWarning
+                empty_row = empty_row.astype(old.dtypes)
                 new = pd.concat([empty_row, old])
                 self.additional_data[k] = new
             elif isinstance(old, pd.Series) and old.index.equals(data.index):
-                empty_row = pd.Series(np.nan, index=[old.index[0] - pd.DateOffset(days=1)])
+                empty_row = pd.Series(np.nan, index=[old.index[0] - pd.DateOffset(days=1)], dtype=old.dtype)
                 new = pd.concat([empty_row, old])
                 self.additional_data[k] = new
 


### PR DESCRIPTION
Summary
Fix pandas FutureWarning caused by concatenating boolean and numeric dtypes in [backtest.py](vscode-file://vscode-app/c:/Users/nehaj/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Changes
Preserve dtype when creating the empty DataFrame row before concat.
Specify dtype when creating empty Series for concat.
Add test to ensure no FutureWarning is raised when [additional_data](vscode-file://vscode-app/c:/Users/nehaj/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) contains boolean columns.
Testing
Local tests: pytest [test_backtest.py](http://_vscodecontentref_/2) -q — all tests passing.
Added a test that confirms no FutureWarning with boolean additional data.
Notes
This fixes issue: pmorissette/bt#412.