### PR TITLE
Handle nested paper-trade strategy bootstrap

### DIFF
--- a/bt/core.py
+++ b/bt/core.py
@@ -794,12 +794,7 @@ class StrategyBase(Node):
                 else:
                     if is_zero(self._value):
                         ret = 0
-                    elif (
-                        self.parent == self
-                        and is_zero(self._capital)
-                        and is_zero(self._last_value)
-                        and is_zero(self._net_flows)
-                    ):
+                    elif self.parent == self and is_zero(self._capital) and is_zero(self._last_value) and is_zero(self._net_flows):
                         # Paper-trade root strategies can open their initial
                         # positions before their synthetic return series has a
                         # non-zero base. Treat that bootstrap step as a flat

--- a/bt/core.py
+++ b/bt/core.py
@@ -794,6 +794,17 @@ class StrategyBase(Node):
                 else:
                     if is_zero(self._value):
                         ret = 0
+                    elif (
+                        self.parent == self
+                        and is_zero(self._capital)
+                        and is_zero(self._last_value)
+                        and is_zero(self._net_flows)
+                    ):
+                        # Paper-trade root strategies can open their initial
+                        # positions before their synthetic return series has a
+                        # non-zero base. Treat that bootstrap step as a flat
+                        # return and let the paper price drive performance.
+                        ret = 0
                     else:
                         raise ZeroDivisionError(
                             "Could not update %s on %s. Last value "

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -264,6 +264,58 @@ def test_Results_helper_functions_fi():
     ).abs().sum() == 0
 
 
+def test_nested_strategy_backtest_handles_initial_paper_trade_value():
+    names = ["foo", "bar", "rf"]
+    dates = pd.date_range("2017-01-01", "2017-12-31", freq=pd.tseries.offsets.BDay())
+    n = len(dates)
+    returns = pd.DataFrame(np.zeros((n, len(names))), index=dates, columns=names)
+
+    np.random.seed(1)
+    returns["foo"] = np.random.normal(loc=0.1 / n, scale=0.2 / np.sqrt(n), size=n)
+    returns["bar"] = np.random.normal(loc=0.04 / n, scale=0.05 / np.sqrt(n), size=n)
+    returns["rf"] = 0.0
+
+    prices = 100 * np.cumprod(1 + returns)
+
+    weights = pd.Series([0.6, 0.2, 0.1], index=returns.columns)
+    leaf = bt.Strategy(
+        "leaf",
+        [
+            bt.algos.RunMonthly(run_on_first_date=True),
+            bt.algos.WeighSpecified(**weights),
+            bt.algos.Rebalance(),
+        ],
+    )
+    middle = bt.Strategy(
+        "middle",
+        [
+            bt.algos.RunMonthly(run_on_first_date=True),
+            bt.algos.SelectAll(),
+            bt.algos.WeighEqually(),
+            bt.algos.Rebalance(),
+        ],
+        children=[leaf, "foo"],
+    )
+    root = bt.Strategy(
+        "root",
+        [
+            bt.algos.RunMonthly(run_on_first_date=True),
+            bt.algos.SelectAll(),
+            bt.algos.WeighEqually(),
+            bt.algos.Rebalance(),
+        ],
+        children=[middle, "bar"],
+    )
+
+    backtest = bt.Backtest(root, prices, integer_positions=False, progress_bar=False)
+
+    result = bt.run(backtest)
+
+    assert isinstance(result.prices, pd.DataFrame)
+    assert np.isfinite(result.prices["root"]).all()
+    assert result.prices["root"].iloc[0] == 100
+
+
 def test_30_min_data():
     names = ["foo"]
     dates = pd.date_range(start="2017-01-01", end="2017-12-31", freq="30min")


### PR DESCRIPTION
## Summary
- avoid raising a zero-base return error when a paper-trade root strategy opens its initial synthetic position
- treat that bootstrap step as a flat return and let the paper price series drive performance
- add a regression test for a three-layer nested strategy backtest

## Testing
- `python -m pytest -q tests/test_backtest.py -k nested_strategy_backtest_handles_initial_paper_trade_value`
- `python -m pytest -q tests/test_core.py -k "fail_if_0_base_in_return_calc or test_strategy_children_paper_trade"`
- `python -m pytest -q tests/test_backtest.py -k "nested_strategy_backtest_handles_initial_paper_trade_value or Results_helper_functions or 30_min_data"`

Closes #433