### PR TITLE
Trim pre-trade flat period from stats

### DIFF
--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -202,6 +202,7 @@ class Backtest:
 
         self.stats = {}
         self._original_prices = None
+        self._stat_prices = None
         self._weights = None
         self._sweights = None
         self.has_run = False
@@ -353,8 +354,19 @@ class Backtest:
                 if self.progress_bar:
                     bar.stop()
 
-        self.stats = self.strategy.prices.calc_perf_stats()
         self._original_prices = self.strategy.prices
+        self._stat_prices = self._compute_stat_prices()
+        self.stats = self._stat_prices.calc_perf_stats()
+
+    def _compute_stat_prices(self):
+        prices = self.strategy.prices
+        transactions = self.strategy.get_transactions()
+
+        if not transactions.empty:
+            first_transaction_date = transactions.index.get_level_values(0)[0]
+            return prices.loc[first_transaction_date:]
+
+        return prices
 
     @property
     def weights(self):
@@ -469,7 +481,7 @@ class Result(ffn.GroupStats):
     """
 
     def __init__(self, *backtests):
-        tmp = [pd.DataFrame({x.name: x.strategy.prices}) for x in backtests]
+        tmp = [pd.DataFrame({x.name: x._stat_prices if x._stat_prices is not None else x.strategy.prices}) for x in backtests]
         super().__init__(*tmp)
         self.backtest_list = backtests
         self.backtests = {x.name: x for x in backtests}

--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -699,7 +699,12 @@ class RenormalizedFixedIncomeResult(Result):
                 raise ValueError(f"Cannot apply RenormalizedFixedIncomeResult because backtest {backtest.name} is not on a fixed income strategy")
         if not isinstance(normalizing_value, dict):
             normalizing_value = {x.name: normalizing_value for x in backtests}
-        tmp = [pd.DataFrame({x.name: self._price(x.strategy, normalizing_value[x.name])}) for x in backtests]
+        tmp = []
+        for backtest in backtests:
+            prices = self._price(backtest.strategy, normalizing_value[backtest.name])
+            if backtest._stat_prices is not None:
+                prices = prices.reindex(backtest._stat_prices.index)
+            tmp.append(pd.DataFrame({backtest.name: prices}))
         super(Result, self).__init__(*tmp)
         self.backtest_list = backtests
         self.backtests = {x.name: x for x in backtests}

--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -360,11 +360,18 @@ class Backtest:
 
     def _compute_stat_prices(self):
         prices = self.strategy.prices
-        transactions = self.strategy.get_transactions()
+        first_transaction_date = None
+        for security in self.strategy.securities:
+            positions = security.positions
+            position_changed = positions.ne(positions.shift(fill_value=0))
+            if position_changed.any():
+                transaction_date = positions.index[position_changed][0]
+                if first_transaction_date is None or transaction_date < first_transaction_date:
+                    first_transaction_date = transaction_date
 
-        if not transactions.empty:
-            first_transaction_date = transactions.index.get_level_values(0)[0]
-            return prices.loc[first_transaction_date:]
+        if first_transaction_date is not None:
+            first_transaction_position = prices.index.get_indexer_for([first_transaction_date])[0]
+            return prices.iloc[max(first_transaction_position - 1, 0) :]
 
         return prices
 

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -316,6 +316,28 @@ def test_nested_strategy_backtest_handles_initial_paper_trade_value():
     assert result.prices["root"].iloc[0] == 100
 
 
+def test_run_after_date_stats_start_on_first_transaction():
+    dates = pd.date_range("2000-01-01", "2002-12-31", freq=pd.tseries.offsets.BDay())
+    prices = pd.DataFrame(index=dates, data={"a": 100.0})
+    prices.loc[dates[260]:, "a"] = np.linspace(100, 150, len(dates[260:]))
+
+    strategy = bt.Strategy(
+        "delayed",
+        [
+            bt.algos.RunAfterDate("2001-01-01"),
+            bt.algos.SelectAll(),
+            bt.algos.WeighEqually(),
+            bt.algos.Rebalance(),
+        ],
+    )
+
+    result = bt.run(bt.Backtest(strategy, prices, progress_bar=False))
+
+    first_transaction_date = result.get_transactions().index.get_level_values(0)[0]
+    assert result.stats["delayed"].start == first_transaction_date
+    assert result.prices.index[0] == first_transaction_date
+
+
 def test_30_min_data():
     names = ["foo"]
     dates = pd.date_range(start="2017-01-01", end="2017-12-31", freq="30min")

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -316,7 +316,7 @@ def test_nested_strategy_backtest_handles_initial_paper_trade_value():
     assert result.prices["root"].iloc[0] == 100
 
 
-def test_run_after_date_stats_start_on_first_transaction():
+def test_run_after_date_stats_include_first_transaction():
     dates = pd.date_range("2000-01-01", "2002-12-31", freq=pd.tseries.offsets.BDay())
     prices = pd.DataFrame(index=dates, data={"a": 100.0})
     prices.loc[dates[260]:, "a"] = np.linspace(100, 150, len(dates[260:]))
@@ -331,11 +331,21 @@ def test_run_after_date_stats_start_on_first_transaction():
         ],
     )
 
-    result = bt.run(bt.Backtest(strategy, prices, progress_bar=False))
+    result = bt.run(
+        bt.Backtest(
+            strategy,
+            prices,
+            commissions=lambda q, p: 100.0,
+            progress_bar=False,
+        )
+    )
 
     first_transaction_date = result.get_transactions().index.get_level_values(0)[0]
-    assert result.stats["delayed"].start == first_transaction_date
-    assert result.prices.index[0] == first_transaction_date
+    first_transaction_position = result.backtests["delayed"].strategy.prices.index.get_loc(first_transaction_date)
+    stats_start = result.backtests["delayed"].strategy.prices.index[first_transaction_position - 1]
+    assert result.stats["delayed"].start == stats_start
+    assert result.prices.index[0] == stats_start
+    assert result.prices.loc[first_transaction_date, "delayed"] < result.prices.loc[stats_start, "delayed"]
 
 
 def test_30_min_data():


### PR DESCRIPTION
## Summary
- trim the leading flat price segment while retaining the observation immediately before the first transaction
- keep the full underlying strategy price series intact for other consumers
- add a regression test for `RunAfterDate` delaying the first trade

## Testing
- `python -m pytest -q tests/test_backtest.py -k "run_after_date_stats_include_first_transaction or nested_strategy_backtest_handles_initial_paper_trade_value"`
- `python -m pytest -q tests/test_core.py -k "fail_if_0_base_in_return_calc or test_strategy_children_paper_trade"`
- `python -m pytest -q tests/test_backtest.py -k "Results_helper_functions or Results_helper_functions_fi or run_after_date_stats_include_first_transaction or nested_strategy_backtest_handles_initial_paper_trade_value"`

Closes #398