### PR TITLE
Fix TargetVol ignoring updated weights when target_volatility is numeric

### DIFF
--- a/bt/algos.py
+++ b/bt/algos.py
@@ -1492,11 +1492,13 @@ class TargetVol(Algo):
         vol = np.sqrt(np.matmul(weights.values.T, np.matmul(covar.values, weights.values)) * self.annualization_factor)
 
         if isinstance(self.target_volatility, (float, int)):
-            self.target_volatility = {k: self.target_volatility for k in target.temp["weights"]}
+            target_volatility = {k: self.target_volatility for k in target.temp["weights"]}
+        else:
+            target_volatility = self.target_volatility
 
         for k in target.temp["weights"]:
-            if k in self.target_volatility:
-                target.temp["weights"][k] = target.temp["weights"][k] * self.target_volatility[k] / vol
+            if k in target_volatility:
+                target.temp["weights"][k] = target.temp["weights"][k] * target_volatility[k] / vol
 
         return True
 

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -1741,6 +1741,7 @@ def test_TargetVol():
     data.loc[dts[4], "c2"] = 99
     data.loc[dts[5], "c2"] = 101
     data.loc[dts[6], "c2"] = 99
+    data["c3"] = data["c2"]
 
     targetVolAlgo = algos.TargetVol(
         0.1,
@@ -1760,6 +1761,11 @@ def test_TargetVol():
     assert np.isclose(weights["c2"], weights["c1"])
 
     unannualized_c2_weight = weights["c1"]
+
+    s.temp["weights"] = {"c3": 1.0}
+    assert targetVolAlgo(s)
+    assert targetVolAlgo.target_volatility == 0.1
+    assert not np.isclose(s.temp["weights"]["c3"], 1.0)
 
     targetVolAlgo = algos.TargetVol(
         0.1 * np.sqrt(252),


### PR DESCRIPTION
If self.target_volatility is set as a number and target.temp["weights"] changes over time, TargetVol doesn’t work correctly. In this situation, the self.target_volatility property is initialized only once, based on the weights at a specific date. When target.temp["weights"] changes, self.target_volatility does not update accordingly.