### PR TITLE
Fix skipped integer allocation with nonlinear commissions

### DIFF
--- a/bt/core.py
+++ b/bt/core.py
@@ -1585,8 +1585,16 @@ class SecurityBase(Node):
                 if self.integer_positions:
                     full_outlay_of_1_more, _, _, _ = self.outlay(q + 1)
 
-                    if full_outlay < amount and full_outlay_of_1_more > amount:
-                        break
+                    if full_outlay < amount:
+                        if full_outlay_of_1_more > amount:
+                            break
+
+                        # The root-search step can skip an affordable integer
+                        # quantity when commissions are non-linear. Move back
+                        # one share so the search keeps the closest affordable
+                        # outlay instead of treating the larger gap as an error.
+                        q += 1
+                        full_outlay = full_outlay_of_1_more
 
                 # if not integer positions then we should keep going until
                 # full_outlay == amount or is close enough

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2401,6 +2401,32 @@ def test_fixed_commissions():
     assert s.capital == 198 + 199 - 101 + 499 + 199
 
 
+def test_integer_positions_with_nonlinear_commissions():
+    c = SecurityBase("c")
+    s = StrategyBase("s", [c])
+
+    def commissions(q, p):
+        return max(0.35, min(abs(q) * 0.0035, abs(q) * p * 0.01))
+
+    s.set_commissions(commissions)
+    c = s["c"]
+
+    dts = pd.date_range("2010-01-01", periods=1)
+    data = pd.DataFrame(index=dts, columns=["c"], data=1.0)
+    s.setup(data)
+    s.update(dts[0], data.loc[dts[0]])
+    s.adjust(1000)
+
+    # Rebalancing from a short position used to skip the affordable quantity
+    # of 285 and raise a "commission fn is not smooth" RuntimeError.
+    c._position = -100
+    c.update(dts[0], data.loc[dts[0]])
+    c.allocate(286)
+
+    assert c.position == 185
+    assert s.capital == pytest.approx(1000 - 285.9975)
+
+
 def test_degenerate_shorting():
     # can have situation where you short infinitely if commission/share > share
     # price


### PR DESCRIPTION
## Summary

- preserve the closest affordable integer quantity when the allocation root search skips over it under nonlinear commissions
- add a regression test using the minimum/per-share/capped commission model reported in #461

## Reproduction

With a $286 allocation at a $1 price while rebalancing from a short position, the search moved from 286 shares to 284 even though 285 shares cost $285.9975 and were affordable. It then raised the `commission fn is not smooth` RuntimeError. The corrected search steps back to 285 shares and completes the allocation.

## Tests

- `python -m pytest -q` — 183 passed
- `make lint` — passed

Fixes #384
Addresses #461