### PR TITLE
Add pytest benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.benchmarks/
 .coverage
 .cache
 nosetests.xml

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,16 @@ TMPREPO=/tmp/docs/bt
 
 default: build_dev
 
-.PHONY: dist upload docs pages serve klink notebooks test lint fix develop
+.PHONY: dist upload docs pages serve klink notebooks test benchmark lint fix develop
 
 develop:
 	python -m pip install -e .[dev]
 
 test:
 	python -m pytest -vvv tests --cov=bt --junitxml=python_junit.xml --cov-report=xml --cov-branch --cov-report term
+
+benchmark:
+	python -m pytest -vv benchmarks --benchmark-only
 
 lint:
 	python -m ruff check bt docs/source/conf.py

--- a/benchmarks/test_backtest.py
+++ b/benchmarks/test_backtest.py
@@ -1,0 +1,89 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import bt
+
+
+@pytest.fixture(
+    scope="module",
+    params=[(252, 10), (1000, 50)],
+    ids=["1y-10-assets", "4y-50-assets"],
+)
+def prices(request):
+    periods, assets = request.param
+    rng = np.random.default_rng(42)
+    returns = rng.normal(0.0002, 0.01, size=(periods, assets))
+    return pd.DataFrame(
+        100.0 * np.exp(returns.cumsum(axis=0)),
+        index=pd.date_range("2010-01-01", periods=periods, freq="B"),
+        columns=[f"asset_{index}" for index in range(assets)],
+    )
+
+
+@pytest.fixture(scope="module")
+def fixed_income_data(prices):
+    return {
+        "bidoffer": prices * 0.001,
+        "coupons": prices * 0.0001,
+    }
+
+
+def make_strategy(name):
+    return bt.Strategy(
+        name,
+        [
+            bt.algos.RunMonthly(),
+            bt.algos.SelectAll(),
+            bt.algos.WeighEqually(),
+            bt.algos.Rebalance(),
+        ],
+    )
+
+
+def run_equity_backtest(prices):
+    backtest = bt.Backtest(make_strategy("equity"), prices)
+    return bt.run(backtest, progress_bar=False)
+
+
+def run_fixed_income_backtest(prices, additional_data):
+    strategy = bt.FixedIncomeStrategy(
+        "fixed-income",
+        [
+            bt.algos.RunMonthly(),
+            bt.algos.SelectAll(),
+            bt.algos.WeighEqually(),
+            bt.algos.Rebalance(),
+        ],
+        children=[bt.CouponPayingSecurity(column) for column in prices.columns],
+    )
+    backtest = bt.Backtest(strategy, prices, additional_data=additional_data)
+    return bt.run(backtest, progress_bar=False)
+
+
+@pytest.fixture(scope="module")
+def completed_strategy(prices):
+    backtest = bt.Backtest(make_strategy("history"), prices)
+    backtest.run()
+    return backtest.strategy
+
+
+@pytest.mark.benchmark(group="backtest")
+def test_equity_backtest(benchmark, prices):
+    result = benchmark(run_equity_backtest, prices)
+
+    assert result.prices.shape[0] == prices.shape[0] + 1
+
+
+@pytest.mark.benchmark(group="backtest")
+def test_fixed_income_backtest(benchmark, prices, fixed_income_data):
+    result = benchmark(run_fixed_income_backtest, prices, fixed_income_data)
+
+    assert result.prices.shape[0] == prices.shape[0] + 1
+
+
+@pytest.mark.benchmark(group="history")
+def test_strategy_prices(benchmark, prices, completed_strategy):
+    result = benchmark(getattr, completed_strategy, "prices")
+
+    assert result.index[-1] == prices.index[-1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "pandas>=0.19",
     "pyprind>=2.11",
     "pytest",
+    "pytest-benchmark",
     "pytest-cov",
     "packaging>=24.2",
     "ruff",


### PR DESCRIPTION
Add deterministic pytest-benchmark coverage for equity and fixed-income backtests plus public price-history access across representative dataset sizes.