### PR TITLE
Fix AlgoStack branching example

### DIFF
--- a/docs/source/algos.rst
+++ b/docs/source/algos.rst
@@ -223,7 +223,7 @@ can be added by placing those algos at the head of the relevant stack.
                         # Downstream algos could go here...
                         )
     
-    s = bt.Strategy('strategy', branch_stack, ['spy', 'agg'])
+    s = bt.Strategy('strategy', [branch_stack], ['spy', 'agg'])
     t = bt.Backtest(s, data)
     r = bt.run(t)
 


### PR DESCRIPTION
The branching example passes an `AlgoStack` where `Strategy` expects an iterable of algos. Wrap it in a list so the documented example runs.

Validation: reproduced the current `TypeError` and verified the corrected constructor succeeds.

Fixes #314