### PR TITLE
Fix auxiliary data bootstrap dtypes

### DIFF
--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -300,12 +300,8 @@ class Backtest:
         # and add in the first row as well (i.e. "bidoffer")
         for k in self.additional_data:
             old = self.additional_data[k]
-            if isinstance(old, pd.DataFrame) and old.index.equals(data.index):
+            if isinstance(old, (pd.DataFrame, pd.Series)) and old.index.equals(data.index):
                 self.additional_data[k] = self._prepend_missing_row(old)
-            elif isinstance(old, pd.Series) and old.index.equals(data.index):
-                empty_row = pd.Series(np.nan, index=[old.index[0] - pd.DateOffset(days=1)], dtype=old.dtype)
-                new = pd.concat([empty_row, old])
-                self.additional_data[k] = new
 
     def run(self):
         """

--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -218,16 +218,20 @@ class Backtest:
         if not volatility.columns.equals(data.columns):
             raise ValueError("`volatility` columns must match `data` columns.")
 
+    @staticmethod
+    def _prepend_missing_row(data):
+        """Prepend an all-missing row, promoting non-nullable column dtypes."""
+        # Expand positionally so duplicate date labels retain their existing behavior.
+        positional = data.set_axis(pd.RangeIndex(len(data)))
+        positional = positional.reindex(pd.RangeIndex(-1, len(data)))
+        index = data.index.insert(0, data.index[0] - pd.DateOffset(days=1))
+        return positional.set_axis(index)
+
     def _align_impact_frame(self, df):
         """Prepend the t0-1 NaN row that ``_process_data`` adds to ``data``,
         so per-bar lookups by ``security.now`` always resolve.
         """
-        empty_row = pd.DataFrame(
-            np.nan,
-            columns=df.columns,
-            index=[df.index[0] - pd.DateOffset(days=1)],
-        ).astype(df.dtypes)
-        return pd.concat([empty_row, df])
+        return self._prepend_missing_row(df)
 
     def _install_cost_model_hook(self):
         """Wire per-security ``commission`` after strategy setup. Also covers
@@ -297,15 +301,7 @@ class Backtest:
         for k in self.additional_data:
             old = self.additional_data[k]
             if isinstance(old, pd.DataFrame) and old.index.equals(data.index):
-                empty_row = pd.DataFrame(
-                    np.nan,
-                    columns=old.columns,
-                    index=[old.index[0] - pd.DateOffset(days=1)],
-                )
-                # Ensure dtypes match to avoid FutureWarning
-                empty_row = empty_row.astype(old.dtypes)
-                new = pd.concat([empty_row, old])
-                self.additional_data[k] = new
+                self.additional_data[k] = self._prepend_missing_row(old)
             elif isinstance(old, pd.Series) and old.index.equals(data.index):
                 empty_row = pd.Series(np.nan, index=[old.index[0] - pd.DateOffset(days=1)], dtype=old.dtype)
                 new = pd.concat([empty_row, old])

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -403,14 +403,15 @@ def test_RenomalizedFixedIncomeResult():
     assert norm_res.stats["s"].total_return == res.stats["s"].total_return
     assert norm_res.prices.equals(res.prices)
 
-def test_additional_data_boolean_dtype_no_warning():
-    """Test that boolean dtype in additional_data doesn't raise FutureWarning."""
+
+def test_additional_data_auxiliary_bootstrap_boolean_dtype_no_warning():
+    """Test that the bootstrap row stays missing without a bool concat warning."""
     import warnings
 
     dts = pd.date_range("2010-01-01", periods=5)
     data = pd.DataFrame(index=dts, columns=["a", "b"], data=100.0)
 
-    # Create additional data with boolean dtype
+    # Exercise NumPy bool while retaining the warning regression covered by this test.
     signal = pd.DataFrame(
         index=dts,
         columns=["signal"],
@@ -421,17 +422,55 @@ def test_additional_data_boolean_dtype_no_warning():
         "test", [bt.algos.SelectAll(), bt.algos.WeighEqually(), bt.algos.Rebalance()]
     )
 
-    # Capture warnings
+    # Require both the missing-row contract and warning-free pandas concatenation.
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         t = bt.Backtest(s, data, additional_data={"signal": signal}, progress_bar=False)
         t.run()
 
-        # Check no FutureWarning about bool-dtype concatenation
+        assert pd.isna(t.additional_data["signal"].iloc[0, 0])
+        pd.testing.assert_frame_equal(
+            t.additional_data["signal"].iloc[1:],
+            signal,
+            check_dtype=False,
+            check_freq=False,
+        )
+
         future_warnings = [warning for warning in w
                           if issubclass(warning.category, FutureWarning)
                           and "bool-dtype" in str(warning.message).lower()]
         assert len(future_warnings) == 0
+
+
+@pytest.mark.parametrize(
+    ("dtype", "values", "expected_dtype"),
+    [
+        ("int64", [1, 0, 1, 0, 1], "float64"),
+        ("Int64", [1, 0, 1, 0, 1], "Int64"),
+        ("boolean", [True, False, True, False, True], "boolean"),
+        ("float64", [1, 0, 1, 0, 1], "float64"),
+    ],
+)
+def test_additional_data_auxiliary_bootstrap_dtypes(dtype, values, expected_dtype):
+    """Preserve dated auxiliary values while making the bootstrap row missing."""
+    dates = pd.date_range("2010-01-01", periods=5)
+    data = pd.DataFrame(100.0, index=dates, columns=["a"])
+    auxiliary = pd.DataFrame({"value": pd.Series(values, index=dates, dtype=dtype)})
+    strategy = bt.Strategy("test", [])
+
+    backtest = bt.Backtest(
+        strategy,
+        data,
+        additional_data={"auxiliary": auxiliary},
+        progress_bar=False,
+    )
+    processed = backtest.additional_data["auxiliary"]
+
+    # The synthetic row may widen dtype, but it must not alter dated observations.
+    assert processed.index[0] == dates[0] - pd.DateOffset(days=1)
+    assert processed.iloc[0].isna().all()
+    assert str(processed.dtypes["value"]) == expected_dtype
+    pd.testing.assert_frame_equal(processed.iloc[1:], auxiliary, check_dtype=False, check_freq=False)
 
 
 def _impact_universe(n_periods=60, n_securities=3, seed=0):
@@ -458,6 +497,62 @@ def _ew_strategy(name="ew"):
             bt.algos.Rebalance(),
         ],
     )
+
+
+@pytest.mark.parametrize("cost_model_type", [bt.SqrtCostModel, bt.AlmgrenChrissCostModel])
+def test_backtest_integer_volume_matches_float_volume(cost_model_type):
+    """Treat integer and equivalent float volume identically in cost models."""
+    prices, float_volume, volatility = _impact_universe()
+    integer_volume = float_volume.astype("int64")
+
+    # Use float volume as the numerical reference for each nonlinear cost model.
+    float_backtest = bt.Backtest(
+        _ew_strategy(),
+        prices,
+        name="float_volume",
+        commissions=cost_model_type(),
+        volume=float_volume,
+        volatility=volatility,
+        initial_capital=10_000_000.0,
+        progress_bar=False,
+    )
+    integer_backtest = bt.Backtest(
+        _ew_strategy(),
+        prices,
+        name="integer_volume",
+        commissions=cost_model_type(),
+        volume=integer_volume,
+        volatility=volatility,
+        initial_capital=10_000_000.0,
+        progress_bar=False,
+    )
+
+    float_backtest.run()
+    integer_backtest.run()
+
+    # Alignment changes representation only; observed volume must remain unchanged.
+    aligned_integer_volume = integer_backtest.volume
+    assert aligned_integer_volume is not None
+    assert aligned_integer_volume.iloc[0].isna().all()
+    pd.testing.assert_frame_equal(
+        aligned_integer_volume.iloc[1:],
+        integer_volume,
+        check_dtype=False,
+        check_freq=False,
+    )
+
+    # Derive trades independently from position changes rather than result helpers.
+    integer_positions = pd.DataFrame({security.name: security.positions for security in integer_backtest.strategy.securities})
+    float_positions = pd.DataFrame({security.name: security.positions for security in float_backtest.strategy.securities})
+    integer_trades = integer_positions.diff()
+    integer_trades.iloc[0] = integer_positions.iloc[0]
+    float_trades = float_positions.diff()
+    float_trades.iloc[0] = float_positions.iloc[0]
+    pd.testing.assert_frame_equal(integer_trades, float_trades)
+
+    # Cost-model accounting must match for numerically equivalent volume inputs.
+    np.testing.assert_allclose(integer_backtest.strategy.prices, float_backtest.strategy.prices)
+    np.testing.assert_allclose(integer_backtest.strategy.fees, float_backtest.strategy.fees)
 
 
 def test_backtest_cost_model_runs_and_charges_fees():

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -404,7 +404,8 @@ def test_RenomalizedFixedIncomeResult():
     assert norm_res.prices.equals(res.prices)
 
 
-def test_additional_data_auxiliary_bootstrap_boolean_dtype_no_warning():
+@pytest.mark.parametrize("as_series", [False, True], ids=["dataframe", "series"])
+def test_additional_data_auxiliary_bootstrap_boolean_dtype_no_warning(as_series):
     """Test that the bootstrap row stays missing without a bool concat warning."""
     import warnings
 
@@ -412,11 +413,9 @@ def test_additional_data_auxiliary_bootstrap_boolean_dtype_no_warning():
     data = pd.DataFrame(index=dts, columns=["a", "b"], data=100.0)
 
     # Exercise NumPy bool while retaining the warning regression covered by this test.
-    signal = pd.DataFrame(
-        index=dts,
-        columns=["signal"],
-        data=[True, False, True, False, True]
-    )
+    signal = pd.Series([True, False, True, False, True], index=dts, name="signal")
+    if not as_series:
+        signal = signal.to_frame()
 
     s = bt.Strategy(
         "test", [bt.algos.SelectAll(), bt.algos.WeighEqually(), bt.algos.Rebalance()]
@@ -428,13 +427,12 @@ def test_additional_data_auxiliary_bootstrap_boolean_dtype_no_warning():
         t = bt.Backtest(s, data, additional_data={"signal": signal}, progress_bar=False)
         t.run()
 
-        assert pd.isna(t.additional_data["signal"].iloc[0, 0])
-        pd.testing.assert_frame_equal(
-            t.additional_data["signal"].iloc[1:],
-            signal,
-            check_dtype=False,
-            check_freq=False,
-        )
+        processed = t.additional_data["signal"]
+        assert np.asarray(pd.isna(processed.iloc[0])).all()
+        if as_series:
+            pd.testing.assert_series_equal(processed.iloc[1:], signal, check_dtype=False, check_freq=False)
+        else:
+            pd.testing.assert_frame_equal(processed.iloc[1:], signal, check_dtype=False, check_freq=False)
 
         future_warnings = [warning for warning in w
                           if issubclass(warning.category, FutureWarning)


### PR DESCRIPTION
## Summary

Preserve the missing synthetic bootstrap row when bt preprocesses integer and
boolean auxiliary data, volume, and volatility inputs.

## Problem

`Backtest` prepends a synthetic `t0 - 1 day` row so initial trading activity is
measured from a clean starting point. The existing preprocessing casts that
all-missing row back to each source column's dtype.

With pandas 3.0.5, this causes:

- NumPy `int64` `additional_data` and volume frames to raise
  `IntCastingNaNError` during `Backtest` construction.
- NumPy `bool` auxiliary inputs to store `True`, rather than a missing value, in
  the synthetic row.

Nullable integer, nullable boolean, and floating-point frames already represent
the missing row correctly.

## Change

Add a private helper that expands a DataFrame or Series
positionally before restoring its date index. This allows pandas to promote non-nullable NumPy dtypes only when
needed to represent the missing row.

Use the helper for:

- DataFrame and Series entries in `additional_data`.
- Volume and volatility impact frames.

Positional expansion preserves existing duplicate date labels. DataFrames and Series share the same missing-row path.

## Verification

The fail-before regression matrix produced five intended failures and three
passing controls.

After the fix:

- Focused dtype and cost-model tests: 8 passed.
- Complete affected module: 29 passed.
- Full repository suite: 189 passed.
- Native Ruff lint and format checks passed.
- Direct checks of the changed legacy test module introduced no new Ruff,
  formatting, or Pyright diagnostics.

The existing pandas copy-on-write warnings remain unchanged and are unrelated
to this change.

## Independent reference and portfolio invariants

The regression coverage verifies that:

- The sole added index is one day before the first source date.
- Every value in the synthetic row is missing.
- All user-supplied dates, labels, and observations remain unchanged.
- Nullable and floating-point dtypes are retained.
- NumPy integer and boolean dtypes are promoted only when necessary.
- Equivalent integer and floating-point volume inputs produce identical trades,
  fees, and strategy prices under both `SqrtCostModel` and
  `AlmgrenChrissCostModel`.

The preprocessing is shared by flat and nested strategy trees, but this change
does not alter allocation, recursion, aggregation, accounting, or trading-loop
behavior.

## Scope exclusions

This PR does not change cost-model formulas, volume filling limits, alignment
policy, public APIs, dependencies, packaging, Cythonized core behavior, or
broader dtype normalization.