### PR TITLE
Stop SelectWhere on missing signal dates

### DIFF
--- a/bt/algos.py
+++ b/bt/algos.py
@@ -693,7 +693,9 @@ class SelectWhere(Algo):
     Selects securities based on an indicator DataFrame.
 
     Selects securities where the value is True on the current date
-    (target.now) only if current date is present in signal DataFrame.
+    (target.now). If the date is absent from the signal DataFrame, returns
+    False to stop the AlgoStack. A present all-False row remains a valid empty
+    selection and returns True.
 
     For example, this could be the result of a pandas boolean comparison such
     as data > 100.
@@ -743,8 +745,10 @@ class SelectWhere(Algo):
                 else:
                     selected = list(universe[universe > 0].index)
             target.temp["selected"] = list(selected)
+            return True
 
-        return True
+        # Stop downstream Algos when no signal row exists for the current date.
+        return False
 
 
 class SelectRandomly(AlgoStack):

--- a/docs/source/examples-nb.ipynb
+++ b/docs/source/examples-nb.ipynb
@@ -145,6 +145,7 @@
     "    Selects securities based on an indicator DataFrame.\n",
     "    \n",
     "    Selects securities where the value is True on the current date (target.now).\n",
+    "    Stops the AlgoStack if the current date is absent from the signal DataFrame.\n",
     "    \n",
     "    Args:\n",
     "        * signal (DataFrame): DataFrame containing the signal (boolean DataFrame)\n",
@@ -166,9 +167,10 @@
     "\n",
     "            # save in temp - this will be used by the weighing algo\n",
     "            target.temp['selected'] = selected\n",
+    "            return True\n",
     "        \n",
-    "        # return True because we want to keep on moving down the stack\n",
-    "        return True"
+    "        # stop the stack when no selection was available for this date\n",
+    "        return False"
    ]
   },
   {

--- a/docs/source/examples-nb.rst
+++ b/docs/source/examples-nb.rst
@@ -89,6 +89,7 @@ Let’s see how the implementation looks like.
         Selects securities based on an indicator DataFrame.
         
         Selects securities where the value is True on the current date (target.now).
+        Stops the AlgoStack if the current date is absent from the signal DataFrame.
         
         Args:
             * signal (DataFrame): DataFrame containing the signal (boolean DataFrame)
@@ -110,9 +111,10 @@ Let’s see how the implementation looks like.
     
                 # save in temp - this will be used by the weighing algo
                 target.temp['selected'] = selected
+                return True
             
-            # return True because we want to keep on moving down the stack
-            return True
+            # stop the stack when no selection was available for this date
+            return False
 
 
 So there we have it. Our selection Algo. 

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -977,6 +977,94 @@ def test_select_where_legacy():
     assert s.temp["selected"] == ["c2"]
 
 
+def test_select_where_missing_date_product_matrix():
+    dts = pd.date_range("2010-01-01", periods=2)
+    data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100.0)
+
+    # Cross both supported signal paths with NumPy and nullable boolean dtypes.
+    bool_signal = pd.DataFrame([[False, False]], index=[dts[0]], columns=data.columns, dtype=bool)
+    nullable_signal = bool_signal.astype("boolean")
+    for signal in [bool_signal, nullable_signal]:
+        for use_named_data in [False, True]:
+            s = bt.Strategy("s")
+            s.setup(data, where=signal)
+            s.update(dts[1])
+            algo = algos.SelectWhere("where" if use_named_data else signal)
+
+            # An absent row stops the stack without creating an empty selection.
+            assert not algo(s)
+            assert "selected" not in s.temp
+
+            # A present all-false row remains a valid empty selection.
+            s.update(dts[0])
+            assert algo(s)
+            assert s.temp["selected"] == []
+
+
+def test_select_where_missing_date_stops_algo_stack():
+    dts = pd.date_range("2010-01-01", periods=2)
+    data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100.0)
+    signal = pd.DataFrame([[True, False]], index=[dts[0]], columns=data.columns)
+    s = bt.Strategy("s")
+    s.setup(data)
+    s.update(dts[1])
+
+    # A prior selector may leave state behind, so the return value must stop downstream weighting.
+    stack = bt.AlgoStack(algos.SelectAll(), algos.SelectWhere(signal), algos.WeighEqually())
+    assert not stack(s)
+    assert s.temp["selected"] == ["c1", "c2"]
+    assert "weights" not in s.temp
+
+
+def test_select_where_sparse_signal_holds_and_resumes_flat_and_nested():
+    dts = pd.date_range("2010-01-01", periods=3)
+    data = pd.DataFrame(index=dts, columns=["c1", "c2", "c3"], data=100.0)
+    flat_data = data.drop(columns="c3")
+    signal = pd.DataFrame(
+        [[True, False], [False, True]],
+        index=[dts[0], dts[2]],
+        columns=["c1", "c2"],
+    )
+
+    # The flat strategy should hold its day-1 quantity across the missing signal date.
+    flat = bt.Strategy(
+        "flat",
+        [algos.SelectWhere("signal"), algos.WeighEqually(), algos.Rebalance()],
+    )
+    flat_backtest = bt.Backtest(flat, flat_data, additional_data={"signal": signal}, initial_capital=1000)
+    bt.run(flat_backtest)
+
+    assert flat_backtest.strategy["c1"].positions.loc[dts].tolist() == [10.0, 10.0, 0.0]
+    assert flat_backtest.strategy["c2"].positions.loc[dts].tolist() == [0.0, 0.0, 10.0]
+    assert flat_backtest.strategy["c1"].positions.loc[dts[1]] == 10.0
+    assert flat_backtest.strategy["c2"].positions.loc[dts[1]] == 0.0
+
+    # In a nested tree, the sparse child holds while its independently invested sibling continues.
+    sparse_child = bt.Strategy(
+        "sparse",
+        [algos.SelectWhere("signal"), algos.WeighEqually(), algos.Rebalance()],
+    )
+    sibling = bt.Strategy(
+        "sibling",
+        [algos.RunOnce(), algos.SelectThese(["c3"]), algos.WeighEqually(), algos.Rebalance()],
+    )
+    parent = bt.Strategy(
+        "parent",
+        [algos.RunOnce(), algos.SelectAll(), algos.WeighEqually(), algos.Rebalance()],
+        children=[sparse_child, sibling],
+    )
+    nested_backtest = bt.Backtest(parent, data, additional_data={"signal": signal}, initial_capital=2000)
+    bt.run(nested_backtest)
+
+    sparse_result = nested_backtest.strategy["sparse"]
+    sibling_result = nested_backtest.strategy["sibling"]
+    assert sparse_result["c1"].positions.loc[dts].tolist() == [10.0, 10.0, 0.0]
+    assert sparse_result["c2"].positions.loc[dts].tolist() == [0.0, 0.0, 10.0]
+    assert sibling_result["c3"].positions.loc[dts].tolist() == [10.0, 10.0, 10.0]
+    assert sparse_result.values.loc[dts].tolist() == [1000.0, 1000.0, 1000.0]
+    assert sibling_result.values.loc[dts].tolist() == [1000.0, 1000.0, 1000.0]
+
+
 def test_select_regex():
     s = bt.Strategy("s")
     algo = algos.SelectRegex("c1")

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -977,28 +977,16 @@ def test_select_where_legacy():
     assert s.temp["selected"] == ["c2"]
 
 
-def test_select_where_missing_date_product_matrix():
+def test_select_where_missing_date():
     dts = pd.date_range("2010-01-01", periods=2)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100.0)
+    signal = pd.DataFrame([[True, False]], index=[dts[0]], columns=data.columns)
+    s = bt.Strategy("s")
+    s.setup(data, where=signal)
+    s.update(dts[1])
 
-    # Cross both supported signal paths with NumPy and nullable boolean dtypes.
-    bool_signal = pd.DataFrame([[False, False]], index=[dts[0]], columns=data.columns, dtype=bool)
-    nullable_signal = bool_signal.astype("boolean")
-    for signal in [bool_signal, nullable_signal]:
-        for use_named_data in [False, True]:
-            s = bt.Strategy("s")
-            s.setup(data, where=signal)
-            s.update(dts[1])
-            algo = algos.SelectWhere("where" if use_named_data else signal)
-
-            # An absent row stops the stack without creating an empty selection.
-            assert not algo(s)
-            assert "selected" not in s.temp
-
-            # A present all-false row remains a valid empty selection.
-            s.update(dts[0])
-            assert algo(s)
-            assert s.temp["selected"] == []
+    assert not algos.SelectWhere("where")(s)
+    assert "selected" not in s.temp
 
 
 def test_select_where_missing_date_stops_algo_stack():
@@ -1009,60 +997,10 @@ def test_select_where_missing_date_stops_algo_stack():
     s.setup(data)
     s.update(dts[1])
 
-    # A prior selector may leave state behind, so the return value must stop downstream weighting.
     stack = bt.AlgoStack(algos.SelectAll(), algos.SelectWhere(signal), algos.WeighEqually())
     assert not stack(s)
     assert s.temp["selected"] == ["c1", "c2"]
     assert "weights" not in s.temp
-
-
-def test_select_where_sparse_signal_holds_and_resumes_flat_and_nested():
-    dts = pd.date_range("2010-01-01", periods=3)
-    data = pd.DataFrame(index=dts, columns=["c1", "c2", "c3"], data=100.0)
-    flat_data = data.drop(columns="c3")
-    signal = pd.DataFrame(
-        [[True, False], [False, True]],
-        index=[dts[0], dts[2]],
-        columns=["c1", "c2"],
-    )
-
-    # The flat strategy should hold its day-1 quantity across the missing signal date.
-    flat = bt.Strategy(
-        "flat",
-        [algos.SelectWhere("signal"), algos.WeighEqually(), algos.Rebalance()],
-    )
-    flat_backtest = bt.Backtest(flat, flat_data, additional_data={"signal": signal}, initial_capital=1000)
-    bt.run(flat_backtest)
-
-    assert flat_backtest.strategy["c1"].positions.loc[dts].tolist() == [10.0, 10.0, 0.0]
-    assert flat_backtest.strategy["c2"].positions.loc[dts].tolist() == [0.0, 0.0, 10.0]
-    assert flat_backtest.strategy["c1"].positions.loc[dts[1]] == 10.0
-    assert flat_backtest.strategy["c2"].positions.loc[dts[1]] == 0.0
-
-    # In a nested tree, the sparse child holds while its independently invested sibling continues.
-    sparse_child = bt.Strategy(
-        "sparse",
-        [algos.SelectWhere("signal"), algos.WeighEqually(), algos.Rebalance()],
-    )
-    sibling = bt.Strategy(
-        "sibling",
-        [algos.RunOnce(), algos.SelectThese(["c3"]), algos.WeighEqually(), algos.Rebalance()],
-    )
-    parent = bt.Strategy(
-        "parent",
-        [algos.RunOnce(), algos.SelectAll(), algos.WeighEqually(), algos.Rebalance()],
-        children=[sparse_child, sibling],
-    )
-    nested_backtest = bt.Backtest(parent, data, additional_data={"signal": signal}, initial_capital=2000)
-    bt.run(nested_backtest)
-
-    sparse_result = nested_backtest.strategy["sparse"]
-    sibling_result = nested_backtest.strategy["sibling"]
-    assert sparse_result["c1"].positions.loc[dts].tolist() == [10.0, 10.0, 0.0]
-    assert sparse_result["c2"].positions.loc[dts].tolist() == [0.0, 0.0, 10.0]
-    assert sibling_result["c3"].positions.loc[dts].tolist() == [10.0, 10.0, 10.0]
-    assert sparse_result.values.loc[dts].tolist() == [1000.0, 1000.0, 1000.0]
-    assert sibling_result.values.loc[dts].tolist() == [1000.0, 1000.0, 1000.0]
 
 
 def test_select_regex():


### PR DESCRIPTION
## Summary

Make `SelectWhere` return `False` when `target.now` is absent from its signal index so the AlgoStack stops cleanly instead of continuing without a selection for that date.

A three-date price frame with a `SelectWhere` signal only on the middle date, followed by `WeighEqually` and `Rebalance`, fails on the first date with `KeyError: 'selected'`. If another selector precedes `SelectWhere`, the current `True` return can instead pass that earlier selection downstream even though no signal exists for the date.

## Behavior

Present signal rows retain existing behavior, including an all-false row that returns `True` with an empty selection. A missing signal date now returns `False`, leaves `selected` unset, and prevents ordinary downstream weighting and rebalancing Algos from running. Public signatures, defaults, exports, and numerical conventions are unchanged.

## Regression evidence

- **Fail before:** The missing-date unit test returned `True` without setting `selected`, and the same-stack test continued through `WeighEqually` using an earlier selector's result.
- **Pass after:** The focused regressions verify that a missing row returns `False` without creating a selection and that this return stops downstream weighting even when an earlier selector populated `selected`.

## Verification

- Focused missing-date and AlgoStack regressions passed (`2 passed`).
- The complete affected Algo subsystem passed (`73 passed`).
- Native `make lint` and the full repository suite passed (`192 passed`).
- All eight GitHub Actions jobs passed across Ubuntu, macOS, Windows, pandas 1–3, and NumPy 1–2.
- `git diff --check`, notebook JSON validation, and a conflict-free merge simulation against current upstream passed.

## Scope

Changed files are limited to `bt/algos.py`, `tests/test_algos.py`, `docs/source/examples-nb.ipynb`, and generated companion `docs/source/examples-nb.rst`.

Out of scope: Automatic signal reindexing or filling, timezone coercion, point-in-time fundamental data guidance from issue #529, and changes to all-false rows.
