### PR TITLE
Apply cost models to nested strategies

### DIFF
--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -249,24 +249,55 @@ class Backtest:
 
     def _wire_strategy_tree(self, strategy: bt.core.StrategyBase):
         """Wire direct securities and lazy creation in a strategy tree."""
+        if getattr(strategy, "_cost_model_tree_wired", False):
+            return
+
         original_create = strategy._create_child_if_needed
+        original_add = strategy._add_children
+
+        def hooked_add(children, dc):
+            first_new_child = len(strategy._childrenv)
+            result = original_add(children, dc)
+            for child in strategy._childrenv[first_new_child:]:
+                if isinstance(child, bt.core.SecurityBase):
+                    self._wire_security(child)
+                elif isinstance(child, bt.core.StrategyBase):
+                    self._install_dynamic_strategy_hook(child)
+            return result
 
         def hooked_create(child: str):
             result = original_create(child)
-            sec = strategy.children.get(child)
-            if isinstance(sec, bt.core.SecurityBase):
-                self._wire_security(sec)
+            node = strategy.children.get(child)
+            if isinstance(node, bt.core.SecurityBase):
+                self._wire_security(node)
+            elif isinstance(node, bt.core.StrategyBase):
+                self._wire_nested_strategy(node)
             return result
 
+        strategy._add_children = hooked_add
         strategy._create_child_if_needed = hooked_create
+        strategy._cost_model_tree_wired = True
         for child in strategy._childrenv:
             if isinstance(child, bt.core.SecurityBase):
                 self._wire_security(child)
             elif isinstance(child, bt.core.StrategyBase):
-                self._wire_strategy_tree(child)
-                # Nested strategies price themselves through a separate paper tree.
-                if child._paper_trade:
-                    self._wire_strategy_tree(child._paper)
+                self._wire_nested_strategy(child)
+
+    def _wire_nested_strategy(self, strategy: bt.core.StrategyBase):
+        self._wire_strategy_tree(strategy)
+        # Nested strategies price themselves through a separate paper tree.
+        if strategy._paper_trade:
+            self._wire_strategy_tree(strategy._paper)
+
+    def _install_dynamic_strategy_hook(self, strategy: bt.core.StrategyBase):
+        original_setup_from_parent = strategy.setup_from_parent
+
+        def hooked_setup_from_parent(*args, **kwargs):
+            result = original_setup_from_parent(*args, **kwargs)
+            self._wire_nested_strategy(strategy)
+            return result
+
+        strategy.setup_from_parent = hooked_setup_from_parent
 
     def _wire_security(self, security):
         if getattr(security, "_cost_model_wired", False):

--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -235,28 +235,38 @@ class Backtest:
         return self._prepend_missing_row(df)
 
     def _install_cost_model_hook(self):
-        """Wire per-security ``commission`` after strategy setup. Also covers
-        lazily-created child securities by hooking ``_create_child_if_needed``.
-        """
+        """Wire commissions throughout real and paper trees after setup."""
         original_setup = self.strategy.setup
-        original_create = self.strategy._create_child_if_needed
 
         def hooked_setup(*args, **kwargs):
             result = original_setup(*args, **kwargs)
-            for member in self.strategy.members:
-                if isinstance(member, bt.core.SecurityBase):
-                    self._wire_security(member)
+            strategy = self.strategy
+            assert isinstance(strategy, bt.core.StrategyBase)
+            self._wire_strategy_tree(strategy)
             return result
 
-        def hooked_create(child):
+        self.strategy.setup = hooked_setup
+
+    def _wire_strategy_tree(self, strategy: bt.core.StrategyBase):
+        """Wire direct securities and lazy creation in a strategy tree."""
+        original_create = strategy._create_child_if_needed
+
+        def hooked_create(child: str):
             result = original_create(child)
-            sec = self.strategy.children.get(child)
+            sec = strategy.children.get(child)
             if isinstance(sec, bt.core.SecurityBase):
                 self._wire_security(sec)
             return result
 
-        self.strategy.setup = hooked_setup
-        self.strategy._create_child_if_needed = hooked_create
+        strategy._create_child_if_needed = hooked_create
+        for child in strategy._childrenv:
+            if isinstance(child, bt.core.SecurityBase):
+                self._wire_security(child)
+            elif isinstance(child, bt.core.StrategyBase):
+                self._wire_strategy_tree(child)
+                # Nested strategies price themselves through a separate paper tree.
+                if child._paper_trade:
+                    self._wire_strategy_tree(child._paper)
 
     def _wire_security(self, security):
         if getattr(security, "_cost_model_wired", False):

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -701,6 +701,45 @@ def test_backtest_cost_model_matches_legacy_in_nested_strategies(
     assert cost_leaf.price == pytest.approx(legacy_leaf.price)
 
 
+def test_backtest_cost_model_applies_to_dynamic_nested_strategy():
+    dates = pd.date_range("2020-01-01", periods=2, freq="B")
+    prices = pd.DataFrame({"A": 100.0}, index=dates)
+    volume = pd.DataFrame({"A": 1_000_000.0}, index=dates)
+    volatility = pd.DataFrame({"A": 0.02}, index=dates)
+
+    def add_leaf(target):
+        leaf = bt.Strategy(
+            "leaf",
+            [bt.algos.RunOnce(), bt.algos.SelectAll(), bt.algos.WeighEqually(), bt.algos.Rebalance()],
+            children=["A"],
+            parent=target,
+        )
+        leaf.setup_from_parent()
+        leaf.update(target.now)
+        target.allocate(target.value, leaf.name)
+        return True
+
+    strategy = bt.Strategy("root", [bt.algos.RunOnce(), add_leaf])
+    backtest = bt.Backtest(
+        strategy,
+        prices,
+        commissions=bt.AlmgrenChrissCostModel(alpha=0, beta=0, epsilon=0.01),
+        volume=volume,
+        volatility=volatility,
+        initial_capital=10_000.0,
+        integer_positions=False,
+        progress_bar=False,
+    )
+
+    backtest.run()
+
+    leaf = backtest.strategy["leaf"]
+    expected_quantity = 10_000.0 / 101.0
+    assert leaf["A"].position == pytest.approx(expected_quantity)
+    assert leaf.fees.sum() == pytest.approx(expected_quantity)
+    assert leaf._paper["A"].position == pytest.approx(1_000_000.0 / 101.0)
+
+
 def test_backtest_cost_model_active_ac_costs_higher_than_flat_path():
     prices, volume, volatility = _impact_universe()
     eps = 0.0005

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -635,6 +635,72 @@ def test_backtest_cost_model_ac_zero_alpha_beta_matches_flat_commission():
     )
 
 
+@pytest.mark.parametrize("lazy_security", [False, True], ids=["explicit", "lazy"])
+def test_backtest_cost_model_matches_legacy_in_nested_strategies(
+    lazy_security: bool,
+):
+    dates = pd.date_range("2020-01-01", periods=3, freq="B")
+    prices = pd.DataFrame({"A": 100.0}, index=dates)
+    volume = pd.DataFrame({"A": 1_000_000.0}, index=dates)
+    volatility = pd.DataFrame({"A": 0.02}, index=dates)
+    epsilon = 0.01
+
+    def trade_algos() -> list[bt.Algo]:
+        return [
+            bt.algos.RunOnDate(dates[0]),
+            bt.algos.SelectAll(),
+            bt.algos.WeighEqually(),
+            bt.algos.Rebalance(),
+        ]
+
+    def nested_strategy(name: str) -> bt.Strategy:
+        security = "A" if lazy_security else bt.Security("A")
+        leaf = bt.Strategy("leaf", trade_algos(), children=[security])
+        return bt.Strategy(name, trade_algos(), children=[leaf])
+
+    def legacy_commission(q: float, p: float) -> float:
+        return abs(q) * p * epsilon
+
+    cost_model = bt.Backtest(
+        nested_strategy("cost_model"),
+        prices,
+        commissions=bt.AlmgrenChrissCostModel(alpha=0, beta=0, epsilon=epsilon),
+        volume=volume,
+        volatility=volatility,
+        initial_capital=10_000.0,
+        integer_positions=False,
+        progress_bar=False,
+    )
+    legacy = bt.Backtest(
+        nested_strategy("legacy"),
+        prices,
+        commissions=legacy_commission,
+        initial_capital=10_000.0,
+        integer_positions=False,
+        progress_bar=False,
+    )
+
+    bt.run(cost_model, legacy)
+
+    cost_leaf = cost_model.strategy["leaf"]
+    legacy_leaf = legacy.strategy["leaf"]
+
+    # Derive the real trade and fee directly from the cost-inclusive unit outlay.
+    expected_quantity = 10_000.0 / (100.0 * (1.0 + epsilon))
+    expected_fee = expected_quantity * 100.0 * epsilon
+    assert cost_leaf["A"].position == pytest.approx(expected_quantity)
+    assert cost_leaf.fees.sum() == pytest.approx(expected_fee)
+    assert cost_model.strategy.value == pytest.approx(10_000.0 - expected_fee)
+    assert cost_model.strategy.value == pytest.approx(legacy.strategy.value)
+
+    # Paper strategies trade a fixed independent amount but obey the same cost contract.
+    expected_paper_quantity = 1_000_000.0 / (100.0 * (1.0 + epsilon))
+    expected_paper_fee = expected_paper_quantity * 100.0 * epsilon
+    assert cost_leaf._paper["A"].position == pytest.approx(expected_paper_quantity)
+    assert cost_leaf._paper.fees.sum() == pytest.approx(expected_paper_fee)
+    assert cost_leaf.price == pytest.approx(legacy_leaf.price)
+
+
 def test_backtest_cost_model_active_ac_costs_higher_than_flat_path():
     prices, volume, volatility = _impact_universe()
     eps = 0.0005


### PR DESCRIPTION
## Summary

Install a configured `CostModel` on explicit, lazy, and dynamically added securities throughout real and paper nested strategy trees, preserving flat and legacy-commission behavior.

For $10,000 capital, a $100 security, and `AlmgrenChrissCostModel(alpha=0, beta=0, epsilon=0.01)`, the cost-inclusive quantity is `10000 / (100 * 1.01) = 99.00990099`, the fee is `99.00990099`, and ending equity is `9900.99009901`.

## Behavior

After strategy setup, the backtest recursively wires existing securities and lazy-security creation in every real and paper strategy tree. Child-registration hooks also cover strategies added later through the documented `Strategy(..., parent=...)` and `setup_from_parent()` workflow. Public signatures, defaults, exports, cost formulas, and flat or legacy-callable behavior remain unchanged.

## Regression evidence

- **Initial nested defect:** Explicit paper securities and lazy real/paper securities bypassed the cost model, trading cost-free quantities and charging no fee.
- **Review finding:** A strategy dynamically added after root setup still bypassed all cost wiring. It bought 100 units and charged zero fees instead of buying `99.00990099` units and charging `99.00990099`.
- **Pass after:** Regressions verify cost-model equivalence with the legacy 1% callable for explicit and lazy nested trees, real and paper accounting, and the same contract for dynamically added nested strategies.

## Verification

- Focused nested regressions: `3 passed`.
- Complete backtest subsystem: `33 passed`.
- Full PR-branch suite: `196 passed`.
- `make lint`, Ruff formatting, and `git diff --check` passed.
- Conflict-free merge simulation against current upstream passed.

## Scope

Changed files are limited to `bt/backtest.py` and `tests/test_backtest.py`.

Out of scope: Cost formulas, general fee aggregation, transaction-ledger redesign, core copy-on-write cleanup, and unrelated execution behavior.
