### PR TITLE
Reject unsorted backtest dates

### DIFF
--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -102,8 +102,9 @@ class Backtest:
 
     Args:
         * strategy (Strategy, Node, StrategyBase): The Strategy to be tested.
-        * data (DataFrame): DataFrame containing data used in backtest. This
-          will be the Strategy's "universe".
+        * data (DataFrame): DataFrame containing data used in backtest. The
+          index must be monotonic increasing. This will be the Strategy's
+          "universe".
         * name (str): Backtest name - defaults to strategy name
         * initial_capital (float): Initial amount of capital passed to
           Strategy.
@@ -175,6 +176,10 @@ class Backtest:
         if data.columns.duplicated().any():
             cols = data.columns[data.columns.duplicated().tolist()].tolist()
             raise ValueError(f"data provided has some duplicate column names: \n{cols} \nPlease remove duplicates!")
+
+        # Label-based universe slicing can otherwise expose future rows.
+        if not data.index.is_monotonic_increasing:
+            raise ValueError("data index must be monotonic increasing")
 
         # we want to reuse strategy logic - copy it!
         # basically strategy is a template

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -35,6 +35,18 @@ def test_backtest_dates_set():
     assert actual.dates[-1] == data.index[-1]
 
 
+def test_backtest_rejects_unsorted_dates():
+    s = mock.MagicMock()
+    data = pd.DataFrame(
+        index=pd.to_datetime(["2010-01-03", "2010-01-01", "2010-01-04"]),
+        columns=["a", "b"],
+        data=100,
+    )
+
+    with pytest.raises(ValueError, match="monotonic increasing"):
+        bt.Backtest(s, data, progress_bar=False)
+
+
 def test_backtest_auto_name():
     s = mock.MagicMock()
     s.name = "s"

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -47,6 +47,19 @@ def test_backtest_rejects_unsorted_dates():
         bt.Backtest(s, data, progress_bar=False)
 
 
+def test_backtest_accepts_monotonic_duplicate_dates():
+    s = mock.MagicMock()
+    data = pd.DataFrame(
+        index=pd.to_datetime(["2010-01-01", "2010-01-01", "2010-01-02"]),
+        columns=["a", "b"],
+        data=100,
+    )
+
+    actual = bt.Backtest(s, data, progress_bar=False)
+
+    assert actual.dates[1:].equals(data.index)
+
+
 def test_backtest_auto_name():
     s = mock.MagicMock()
     s.name = "s"


### PR DESCRIPTION
## Summary

Reject a non-monotonic primary data index before `Backtest` constructs its
timeline, rather than allowing Algos to see future rows.

With dates ordered January 3, January 1, January 4, execution on January 1
currently exposes both the synthetic January 2 bootstrap row and the real
January 3 row through `target.universe`.

## Behavior

`Backtest` now requires its primary data index to be monotonic increasing.
Invalid ordering raises `ValueError` before strategy copying or timeline
construction. Monotonic duplicate dates remain accepted and now have committed
compatibility coverage.

## Regression evidence

- Before the fix, the unsorted reproducer completed construction without
  raising and violated the invariant that every visible timestamp must be less
  than or equal to `target.now`.
- Descending, timezone-aware unsorted, and `NaT`-containing indexes are rejected.
- Equivalent sorted input and monotonic duplicate dates remain accepted.
- Duplicate-column validation retains precedence over index-order validation.

## Verification

- Focused index regressions: 2 passed
- Complete affected module: 35 passed, 32 inherited pandas warnings
- Full repository suite: 207 passed, 85 inherited pandas warnings
- Ruff lint and formatting: passed
- `git diff --check`: passed
- Conflict-free merge simulation against current `master`: passed

## Scope

Changed files are limited to:

- `bt/backtest.py`
- `tests/test_backtest.py`

This PR does not silently sort input, redefine duplicate-date semantics, or
change auxiliary-data alignment or timezone policy.
