### PR TITLE
Fix source distribution build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "build",
     "cython>=0.29.25",
     "ffn>=1.1.2",
     "matplotlib>=2",


### PR DESCRIPTION
The release workflow runs `python -m build -s` after installing the development extra, but that extra did not include `build`. Add the missing dependency so tagged releases can produce the source distribution.