### PR TITLE
Build Linux ARM64 wheels on native runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - ubuntu-24.04-arm
           - macos-latest
           - windows-latest
         python-version:
@@ -45,16 +46,11 @@ jobs:
     - name: Install cibuildwheel
       run: python -m pip install cibuildwheel
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
-      with:
-        platforms: all
-      if: runner.os == 'Linux'
-
     - name: Build wheels
       run: python -m cibuildwheel --output-dir dist
       env:
         CIBW_BUILD: "cp311-*"
+        CIBW_ARCHS_LINUX: native
         CIBW_BEFORE_BUILD: "python -c \"from pathlib import Path; [p.unlink() for pattern in ('*.pyd', '*.so', '*.dylib') for p in Path('bt').glob(pattern)]\""
 
     - name: Check Wheels

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - ubuntu-24.04-arm
           - macos-latest
           - windows-latest
         python-version:
@@ -48,17 +49,11 @@ jobs:
     - name: Install cibuildwheel
       run: python -m pip install cibuildwheel
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
-      with:
-        platforms: all
-      if: runner.os == 'Linux'
-
     - name: Python Wheel Steps (Linux - cibuildwheel)
       run: python -m cibuildwheel --output-dir dist
       env:
         CIBW_BUILD: "${{ matrix.cibuildwheel }}-manylinux*"
-        CIBW_ARCHS_LINUX: x86_64 aarch64
+        CIBW_ARCHS_LINUX: native
         CIBW_BUILD_VERBOSITY: 3
       if: ${{ runner.os == 'Linux' }}
 


### PR DESCRIPTION
Add `ubuntu-24.04-arm` to pull-request and release wheel matrices. Each Linux runner now builds its native architecture, preserving x86_64 and aarch64 coverage while removing QEMU emulation.

Validated both workflows with `actionlint` and confirmed cibuildwheel selects `cp311-manylinux_aarch64` for the native ARM64 configuration.