### PR TITLE
Add multi-period momentum lookbacks

### DIFF
--- a/bt/algos.py
+++ b/bt/algos.py
@@ -659,12 +659,13 @@ class SelectMomentum(AlgoStack):
 
     Args:
         * n (int): select first N elements
-        * lookback (DateOffset): lookback period for total return
-          calculation
+        * lookback (DateOffset|list): lookback period for total return
+          calculation, or a list of periods whose returns are averaged
         * lag (DateOffset): Lag interval for total return calculation
         * sort_descending (bool): Sort descending (highest return is best)
         * all_or_none (bool): If true, only populates temp['selected'] if we
           have n items. If we have less than n, then temp['selected'] = [].
+        * weights (list): Optional weights for multiple lookback periods.
 
     Sets:
         * selected
@@ -681,9 +682,17 @@ class SelectMomentum(AlgoStack):
         lag=_DEFAULT_LAG,
         sort_descending=True,
         all_or_none=False,
+        weights=None,
     ):
+        if isinstance(lookback, (list, tuple)):
+            stat = StatMultiPeriodReturn(lookbacks=lookback, weights=weights, lag=lag)
+        else:
+            if weights is not None:
+                raise ValueError("weights require multiple lookback periods")
+            stat = StatTotalReturn(lookback=lookback, lag=lag)
+
         super().__init__(
-            StatTotalReturn(lookback=lookback, lag=lag),
+            stat,
             SelectN(n=n, sort_descending=sort_descending, all_or_none=all_or_none),
         )
 
@@ -952,6 +961,51 @@ class StatTotalReturn(Algo):
             return False
         prc = target.universe.loc[t0 - self.lookback : t0, selected]
         target.temp["stat"] = prc.calc_total_return()
+        return True
+
+
+class StatMultiPeriodReturn(Algo):
+    """
+    Sets temp['stat'] to the weighted average of multiple total returns.
+
+    Args:
+        * lookbacks (list): DateOffset lookback periods.
+        * weights (list): Optional weight for each lookback. Equal weights are
+          used by default. Weights are normalized to sum to one.
+        * lag (DateOffset): Lag interval. Each total return ends at now - lag.
+
+    Sets:
+        * stat
+
+    Requires:
+        * selected
+    """
+
+    def __init__(self, lookbacks, weights=None, lag=_DEFAULT_LAG):
+        super().__init__()
+        self.lookbacks = list(lookbacks)
+        if not self.lookbacks:
+            raise ValueError("lookbacks cannot be empty")
+
+        if weights is None:
+            weights = np.ones(len(self.lookbacks))
+        elif len(weights) != len(self.lookbacks):
+            raise ValueError("weights and lookbacks must have the same length")
+
+        weights = np.asarray(weights, dtype=float)
+        if np.isclose(weights.sum(), 0.0):
+            raise ValueError("weights must not sum to zero")
+        self.weights = weights / weights.sum()
+        self.lag = lag
+
+    def __call__(self, target):
+        selected = target.temp["selected"]
+        t0 = target.now - self.lag
+        if target.universe[selected].index[0] > t0:
+            return False
+
+        returns = [target.universe.loc[t0 - lookback : t0, selected].calc_total_return() for lookback in self.lookbacks]
+        target.temp["stat"] = pd.concat(returns, axis=1).dot(self.weights)
         return True
 
 

--- a/bt/algos.py
+++ b/bt/algos.py
@@ -659,13 +659,14 @@ class SelectMomentum(AlgoStack):
 
     Args:
         * n (int): select first N elements
-        * lookback (DateOffset|list): lookback period for total return
-          calculation, or a list of periods whose returns are averaged
+        * lookback (DateOffset|sequence): lookback period for total return
+          calculation, or a sequence of periods whose returns are averaged
         * lag (DateOffset): Lag interval for total return calculation
         * sort_descending (bool): Sort descending (highest return is best)
         * all_or_none (bool): If true, only populates temp['selected'] if we
           have n items. If we have less than n, then temp['selected'] = [].
-        * weights (list): Optional weights for multiple lookback periods.
+        * weights (sequence): Optional non-negative weights for multiple
+          lookback periods.
 
     Sets:
         * selected
@@ -684,7 +685,7 @@ class SelectMomentum(AlgoStack):
         all_or_none=False,
         weights=None,
     ):
-        if isinstance(lookback, (list, tuple)):
+        if isinstance(lookback, (list, tuple, np.ndarray, pd.Index)):
             stat = StatMultiPeriodReturn(lookbacks=lookback, weights=weights, lag=lag)
         else:
             if weights is not None:
@@ -969,9 +970,10 @@ class StatMultiPeriodReturn(Algo):
     Sets temp['stat'] to the weighted average of multiple total returns.
 
     Args:
-        * lookbacks (list): DateOffset lookback periods.
-        * weights (list): Optional weight for each lookback. Equal weights are
-          used by default. Weights are normalized to sum to one.
+        * lookbacks (sequence): DateOffset lookback periods.
+        * weights (sequence): Optional non-negative weight for each lookback.
+          Equal weights are used by default. Weights are normalized to sum to
+          one.
         * lag (DateOffset): Lag interval. Each total return ends at now - lag.
 
     Sets:
@@ -993,7 +995,9 @@ class StatMultiPeriodReturn(Algo):
             raise ValueError("weights and lookbacks must have the same length")
 
         weights = np.asarray(weights, dtype=float)
-        if np.isclose(weights.sum(), 0.0):
+        if np.any(weights < 0):
+            raise ValueError("weights must be non-negative")
+        if weights.sum() == 0:
             raise ValueError("weights must not sum to zero")
         self.weights = weights / weights.sum()
         self.lag = lag

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -1437,6 +1437,44 @@ def test_stat_multi_period_return():
     assert strategy.temp["stat"]["c2"] == pytest.approx(0.65)
 
 
+def test_stat_multi_period_return_validation():
+    lookbacks = [pd.DateOffset(days=1), pd.DateOffset(days=2)]
+
+    with pytest.raises(ValueError, match="lookbacks cannot be empty"):
+        algos.StatMultiPeriodReturn([])
+    with pytest.raises(ValueError, match="same length"):
+        algos.StatMultiPeriodReturn(lookbacks, weights=[1])
+    with pytest.raises(ValueError, match="non-negative"):
+        algos.StatMultiPeriodReturn(lookbacks, weights=[-1, 2])
+    with pytest.raises(ValueError, match="sum to zero"):
+        algos.StatMultiPeriodReturn(lookbacks, weights=[0, 0])
+
+    algo = algos.StatMultiPeriodReturn(lookbacks, weights=[1e-9, 1e-9])
+    assert algo.weights == pytest.approx([0.5, 0.5])
+
+
+def test_stat_multi_period_return_lag_and_history():
+    dts = pd.date_range("2010-01-01", periods=5)
+    data = pd.DataFrame({"c1": [100.0, 110.0, 120.0, 130.0, 200.0]}, index=dts)
+    strategy = bt.Strategy("s")
+    strategy.setup(data)
+    strategy.update(dts[-1])
+    strategy.temp["selected"] = ["c1"]
+
+    algo = algos.StatMultiPeriodReturn(
+        [pd.DateOffset(days=1)],
+        lag=pd.DateOffset(days=1),
+    )
+    assert algo(strategy)
+    assert strategy.temp["stat"]["c1"] == pytest.approx(130.0 / 120.0 - 1)
+
+    algo = algos.StatMultiPeriodReturn(
+        [pd.DateOffset(days=1)],
+        lag=pd.DateOffset(days=5),
+    )
+    assert not algo(strategy)
+
+
 def test_select_n():
     algo = algos.SelectN(n=1, sort_descending=True)
 
@@ -1538,6 +1576,14 @@ def test_select_momentum_multiple_lookbacks():
     strategy.temp["selected"] = ["c1", "c2"]
     assert algos.SelectMomentum(n=1, lookback=lookbacks, weights=[10, 1])(strategy)
     assert strategy.temp["selected"] == ["c1"]
+
+    strategy.temp["selected"] = ["c1", "c2"]
+    lookbacks = np.array([pd.DateOffset(days=4)])
+    assert algos.SelectMomentum(n=1, lookback=lookbacks)(strategy)
+    assert strategy.temp["selected"] == ["c2"]
+
+    with pytest.raises(ValueError, match="weights require multiple"):
+        algos.SelectMomentum(n=1, weights=[1])
 
 
 def test_limit_weights():

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -1417,6 +1417,26 @@ def test_stat_total_return():
     assert stat["c2"] == pytest.approx(95.0 / 100 - 1)
 
 
+def test_stat_multi_period_return():
+    dts = pd.date_range("2010-01-01", periods=5)
+    data = pd.DataFrame(
+        {
+            "c1": [100.0, 100.0, 100.0, 100.0, 130.0],
+            "c2": [50.0, 100.0, 100.0, 100.0, 110.0],
+        },
+        index=dts,
+    )
+    strategy = bt.Strategy("s")
+    strategy.setup(data)
+    strategy.update(dts[-1])
+    strategy.temp["selected"] = ["c1", "c2"]
+    algo = algos.StatMultiPeriodReturn(lookbacks=[pd.DateOffset(days=1), pd.DateOffset(days=4)])
+
+    assert algo(strategy)
+    assert strategy.temp["stat"]["c1"] == pytest.approx(0.3)
+    assert strategy.temp["stat"]["c2"] == pytest.approx(0.65)
+
+
 def test_select_n():
     algo = algos.SelectN(n=1, sort_descending=True)
 
@@ -1495,6 +1515,29 @@ def test_select_momentum():
     actual = s.temp["selected"]
     assert len(actual) == 1
     assert "c1" in actual
+
+
+def test_select_momentum_multiple_lookbacks():
+    dts = pd.date_range("2010-01-01", periods=5)
+    data = pd.DataFrame(
+        {
+            "c1": [100.0, 100.0, 100.0, 100.0, 130.0],
+            "c2": [50.0, 100.0, 100.0, 100.0, 110.0],
+        },
+        index=dts,
+    )
+    strategy = bt.Strategy("s")
+    strategy.setup(data)
+    strategy.update(dts[-1])
+    strategy.temp["selected"] = ["c1", "c2"]
+    lookbacks = [pd.DateOffset(days=1), pd.DateOffset(days=4)]
+
+    assert algos.SelectMomentum(n=1, lookback=lookbacks)(strategy)
+    assert strategy.temp["selected"] == ["c2"]
+
+    strategy.temp["selected"] = ["c1", "c2"]
+    assert algos.SelectMomentum(n=1, lookback=lookbacks, weights=[10, 1])(strategy)
+    assert strategy.temp["selected"] == ["c1"]
 
 
 def test_limit_weights():


### PR DESCRIPTION
Allows `SelectMomentum.lookback` to accept multiple periods, with equal weighting by default and optional normalized weights. Adds reusable `StatMultiPeriodReturn` and regression coverage while preserving the single-period API.

Closes #357