### PR TITLE
Add monthly maximum drawdown helper

### DIFF
--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -544,7 +544,10 @@ class Result(ffn.GroupStats):
         self[key].display_monthly_returns()
 
     def get_monthly_max_drawdown(self):
-        """Return maximum drawdown calculated from month-end prices."""
+        """Return maximum drawdown from monthly-resampled prices.
+
+        The final, potentially incomplete month is included.
+        """
         return pd.Series(
             {key: self[key].monthly_prices.calc_max_drawdown() for key in self._names},
             name="monthly_max_drawdown",

--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -543,6 +543,13 @@ class Result(ffn.GroupStats):
         key = self._get_backtest(backtest)
         self[key].display_monthly_returns()
 
+    def get_monthly_max_drawdown(self):
+        """Return maximum drawdown calculated from month-end prices."""
+        return pd.Series(
+            {key: self[key].monthly_prices.calc_max_drawdown() for key in self._names},
+            name="monthly_max_drawdown",
+        )
+
     def get_weights(self, backtest=0, filter=None):
         """
 

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -205,6 +205,20 @@ def test_Results_helper_functions():
     assert type(res.get_weights()) is pd.DataFrame
 
 
+def test_get_monthly_max_drawdown():
+    dates = pd.to_datetime(["2020-01-31", "2020-02-14", "2020-02-28", "2020-03-31"])
+    data = pd.DataFrame({"asset": [100.0, 50.0, 90.0, 80.0]}, index=dates)
+    strategy = bt.Strategy(
+        "strategy",
+        [bt.algos.RunOnce(), bt.algos.SelectAll(), bt.algos.WeighEqually(), bt.algos.Rebalance()],
+    )
+
+    result = bt.run(bt.Backtest(strategy, data, progress_bar=False))
+
+    assert result["strategy"].max_drawdown == pytest.approx(-0.5)
+    assert result.get_monthly_max_drawdown()["strategy"] == pytest.approx(-0.2)
+
+
 def test_Results_helper_functions_fi():
 
     names = ["foo", "bar"]

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -206,17 +206,28 @@ def test_Results_helper_functions():
 
 
 def test_get_monthly_max_drawdown():
-    dates = pd.to_datetime(["2020-01-31", "2020-02-14", "2020-02-28", "2020-03-31"])
+    dates = pd.to_datetime(["2020-01-31", "2020-02-14", "2020-02-28", "2020-03-15"])
     data = pd.DataFrame({"asset": [100.0, 50.0, 90.0, 80.0]}, index=dates)
     strategy = bt.Strategy(
         "strategy",
         [bt.algos.RunOnce(), bt.algos.SelectAll(), bt.algos.WeighEqually(), bt.algos.Rebalance()],
     )
+    second_data = pd.DataFrame({"asset": [100.0, 90.0, 110.0, 99.0]}, index=dates)
+    second_strategy = bt.Strategy(
+        "second",
+        [bt.algos.RunOnce(), bt.algos.SelectAll(), bt.algos.WeighEqually(), bt.algos.Rebalance()],
+    )
 
-    result = bt.run(bt.Backtest(strategy, data, progress_bar=False))
+    result = bt.run(
+        bt.Backtest(strategy, data, progress_bar=False),
+        bt.Backtest(second_strategy, second_data, progress_bar=False),
+    )
 
     assert result["strategy"].max_drawdown == pytest.approx(-0.5)
-    assert result.get_monthly_max_drawdown()["strategy"] == pytest.approx(-0.2)
+    pd.testing.assert_series_equal(
+        result.get_monthly_max_drawdown(),
+        pd.Series({"strategy": -0.2, "second": -0.1}, name="monthly_max_drawdown"),
+    )
 
 
 def test_Results_helper_functions_fi():


### PR DESCRIPTION
Adds `Result.get_monthly_max_drawdown()`, calculated from ffn’s existing month-end price series. A regression test distinguishes monthly drawdown from an intramonth decline.

Closes #399