### PR TITLE
Handle zero volatility in TargetVol

### DIFF
--- a/bt/algos.py
+++ b/bt/algos.py
@@ -1523,8 +1523,9 @@ class TargetVol(Algo):
         * temp['weights']
 
     Raises:
-        * ValueError: if the estimated portfolio volatility is non-finite, or
-          if it is zero when an applicable non-zero target is requested.
+        * ValueError: if an applicable target or the estimated portfolio
+          volatility is non-finite, or if the estimated volatility is zero
+          when an applicable non-zero target is requested.
 
     """
 
@@ -1580,6 +1581,9 @@ class TargetVol(Algo):
         applicable_target_volatilities: list[float] = [target_volatility[k] for k in target.temp["weights"] if k in target_volatility]
         if not applicable_target_volatilities:
             return True
+
+        if not np.isfinite(applicable_target_volatilities).all():
+            raise ValueError("Cannot target a non-finite target volatility")
 
         if not np.isfinite(vol):
             raise ValueError("Cannot target volatility from a non-finite portfolio volatility")

--- a/bt/algos.py
+++ b/bt/algos.py
@@ -1522,6 +1522,9 @@ class TargetVol(Algo):
     Requires:
         * temp['weights']
 
+    Raises:
+        * ValueError: if the estimated portfolio volatility is non-finite, or
+          if it is zero when an applicable non-zero target is requested.
 
     """
 
@@ -1572,6 +1575,20 @@ class TargetVol(Algo):
             target_volatility = {k: self.target_volatility for k in target.temp["weights"]}
         else:
             target_volatility = self.target_volatility
+
+        # A target mapping may intentionally omit some or all current weights.
+        applicable_target_volatilities: list[float] = [target_volatility[k] for k in target.temp["weights"] if k in target_volatility]
+        if not applicable_target_volatilities:
+            return True
+
+        if not np.isfinite(vol):
+            raise ValueError("Cannot target volatility from a non-finite portfolio volatility")
+
+        if vol == 0:
+            # Scaling cannot create volatility from zero; zero is already a valid target.
+            if any(value != 0 for value in applicable_target_volatilities):
+                raise ValueError("Cannot target a non-zero volatility from a zero-volatility portfolio")
+            return True
 
         for k in target.temp["weights"]:
             if k in target_volatility:

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -1979,6 +1979,57 @@ def test_TargetVol_rejects_non_finite_volatility():
 
 
 @pytest.mark.parametrize("covar_method", ["standard", "ledoit-wolf"])
+@pytest.mark.parametrize("target_volatility", [np.nan, np.inf, -np.inf])
+@pytest.mark.parametrize("use_mapping", [False, True])
+def test_TargetVol_rejects_non_finite_target(covar_method, target_volatility, use_mapping):
+    dts = pd.date_range("2010-01-01", periods=5)
+    data = pd.DataFrame({"c1": [100.0, 102.0, 99.0, 103.0, 100.0]}, index=dts)
+    data["c2"] = data["c1"]
+    s = bt.Strategy("s")
+    s.setup(data)
+    s.update(dts[-1])
+    initial_weights = {"c1": 0.5, "c2": 0.5}
+    s.temp["weights"] = initial_weights.copy()
+    if use_mapping:
+        target_volatility = {"c1": 0.1, "c2": target_volatility}
+    target_vol_algo = algos.TargetVol(
+        target_volatility,
+        lookback=pd.DateOffset(days=4),
+        lag=pd.DateOffset(days=0),
+        covar_method=covar_method,
+    )
+
+    with pytest.raises(ValueError, match="non-finite target volatility"):
+        target_vol_algo(s)
+    assert s.temp["weights"] == initial_weights
+
+
+@pytest.mark.parametrize("covar_method", ["standard", "ledoit-wolf"])
+@pytest.mark.parametrize("integer_positions", [False, True])
+def test_TargetVol_zero_volatility_backtest(covar_method, integer_positions):
+    dts = pd.date_range("2010-01-01", periods=5)
+    data = pd.DataFrame({"c1": 100.0}, index=dts)
+    s = bt.Strategy(
+        "s",
+        [
+            algos.RunAfterDate(dts[-2]),
+            algos.WeighSpecified(c1=1.0),
+            algos.TargetVol(
+                0.1,
+                lookback=pd.DateOffset(days=4),
+                lag=pd.DateOffset(days=0),
+                covar_method=covar_method,
+            ),
+            algos.Rebalance(),
+        ],
+    )
+    backtest = bt.Backtest(s, data, integer_positions=integer_positions, progress_bar=False)
+
+    with pytest.raises(ValueError, match="zero-volatility"):
+        backtest.run()
+
+
+@pytest.mark.parametrize("covar_method", ["standard", "ledoit-wolf"])
 def test_PTE_Rebalance(covar_method):
 
     s = bt.Strategy("s")

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -1918,6 +1918,67 @@ def test_TargetVol(covar_method):
 
 
 @pytest.mark.parametrize("covar_method", ["standard", "ledoit-wolf"])
+@pytest.mark.parametrize(
+    ("target_volatility", "expected_error"),
+    [
+        (0.1, "zero-volatility"),
+        ({"c1": 0.1}, "zero-volatility"),
+        (0.0, None),
+        ({"c1": 0.0}, None),
+        ({"c2": 0.1}, None),
+    ],
+)
+def test_TargetVol_zero_volatility(
+    covar_method: str,
+    target_volatility: "float | dict[str, float]",
+    expected_error: "str | None",
+):
+    s = bt.Strategy("s")
+    dts = pd.date_range("2010-01-01", periods=5)
+    data = pd.DataFrame(index=dts, columns=["c1"], data=100.0)
+
+    target_vol_algo = algos.TargetVol(
+        target_volatility,
+        lookback=pd.DateOffset(days=4),
+        lag=pd.DateOffset(days=0),
+        covar_method=covar_method,
+        annualization_factor=1,
+    )
+
+    s.setup(data)
+    s.update(dts[-1])
+    initial_weights = {"c1": 1.0}
+    s.temp["weights"] = initial_weights.copy()
+
+    # Preserve satisfied or omitted targets, and reject infeasible targets before mutation.
+    if expected_error is None:
+        assert target_vol_algo(s)
+    else:
+        with pytest.raises(ValueError, match=expected_error):
+            target_vol_algo(s)
+    assert s.temp["weights"] == initial_weights
+
+
+def test_TargetVol_rejects_non_finite_volatility():
+    s = bt.Strategy("s")
+    dts = pd.date_range("2010-01-01", periods=1)
+    data = pd.DataFrame(index=dts, columns=["c1"], data=100.0)
+    target_vol_algo = algos.TargetVol(
+        0.1,
+        lookback=pd.DateOffset(days=1),
+        lag=pd.DateOffset(days=0),
+        annualization_factor=1,
+    )
+
+    s.setup(data)
+    s.update(dts[-1])
+    s.temp["weights"] = {"c1": 1.0}
+
+    with pytest.raises(ValueError, match="non-finite"):
+        target_vol_algo(s)
+
+
+@pytest.mark.parametrize("covar_method", ["standard", "ledoit-wolf"])
 def test_PTE_Rebalance(covar_method):
 
     s = bt.Strategy("s")


### PR DESCRIPTION
## Summary

Prevent `TargetVol` from emitting non-finite target weights when the calculated portfolio volatility is zero, while preserving existing behavior for finite positive volatility.

A one-security portfolio with five constant prices and a positive target volatility produces target weight `inf`; default integer allocation then raises `OverflowError`, while fractional allocation reaches the 10,000-iteration solver guard.

## Behavior

A volatility-targeting Algo must emit finite usable weights or report that the requested target is infeasible before calling the allocation path. It must not pass infinity or NaN downstream.

## Regression evidence

Fail-before is reconfirmed at accepted commit `91003488d3c5c4cd6afa01c4338663998d59abf3`: with constant prices and a positive applicable target, both `standard` and `ledoit-wolf` produce `inf`; integer end-to-end execution raises `OverflowError`, and fractional execution reaches the allocation guard `RuntimeError`. A zero scalar target and zero volatility instead produce `nan`, while a zero current weight with volatile prices produces the same `nan` mechanism. The independent oracle is that no finite scale of a zero-volatility weight vector can attain a positive target. An ordinary varying-price standard-covariance control produces `0.9105887518523383`, exactly matching an independent `sqrt(w.T @ covariance @ w * 252)` calculation. After the fix, every permanent boundary cell passes and the same ordinary calculation remains unchanged.

## Verification

- Focused regression: Both new tests pass with `11 passed`; fail-before was `9 failed, 2 passed`, with the two passing cells being the already-safe unmatched mappings.
- Complete affected subsystem: `tests/test_algos.py` passes with `95 passed` and nine inherited pandas copy-on-write warnings outside `TargetVol`.
- Final full suite: Native `make test` passes with `221 passed` and 48 inherited pandas copy-on-write warnings; generated coverage and JUnit artifacts were removed afterward.
- Static, documentation, API, dependency, or build checks: Native `make lint` passes. Differential Ruff reports zero new findings and 20 inherited test-file findings; production remains formatted and the test file retains only its accepted format debt. Changed-line Pyright reports zero unapproved diagnostics and 621 inherited or indirect diagnostics. `format-new` preview and execution both found no added Python files. `git diff --check` passes. No signature, dependency, export, compiled-core, or build change was made.
- Downstream-impact scan: Repository-wide source, test, documentation, notebook, build-tooling, snapshot, and generated-record searches found only the implementation, Algo tests, and the ordinary positive-volatility notebook/RST example. That path is protected by the existing parameterized test; no pinned textual output, generator, or additional file requires a change.

## Scope

Changed files are limited to `bt/algos.py`, `tests/test_algos.py`

Out of scope: General leverage limits, covariance-estimation redesign, singular nonzero covariance portfolios, and changes to `PTE_Rebalance`.