### PR TITLE
fix(algos): keep weekly schedules within ISO weeks

### DIFF
--- a/bt/algos.py
+++ b/bt/algos.py
@@ -226,7 +226,7 @@ class RunWeekly(RunPeriod):
     """
 
     def compare_dates(self, now, date_to_compare):
-        return bool(now.year != date_to_compare.year or now.week != date_to_compare.week)
+        return now.isocalendar()[:2] != date_to_compare.isocalendar()[:2]
 
 
 class RunMonthly(RunPeriod):

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -147,6 +147,43 @@ def test_run_daily():
     assert algo(target)
 
 
+@pytest.mark.parametrize(
+    "start,expected_start,expected_end",
+    [
+        ("2015-12-28", "2016-01-04", "2016-01-03"),
+        ("2018-12-28", "2018-12-31", "2018-12-30"),
+    ],
+)
+@pytest.mark.parametrize("run_on_end_of_period", [False, True])
+def test_run_weekly_does_not_split_an_iso_week_at_new_year(
+    start, expected_start, expected_end, run_on_end_of_period
+):
+    class RecordDates(bt.Algo):
+        def __init__(self):
+            self.dates = []
+
+        def __call__(self, target):
+            self.dates.append(target.now)
+            return True
+
+    data = pd.DataFrame({"asset": 100.0}, index=pd.date_range(start, periods=9))
+    strategy = bt.Strategy(
+        "weekly",
+        [
+            algos.RunWeekly(
+                run_on_first_date=False,
+                run_on_end_of_period=run_on_end_of_period,
+            ),
+            RecordDates(),
+        ],
+    )
+    backtest = bt.Backtest(strategy, data)
+    backtest.run()
+
+    expected = expected_end if run_on_end_of_period else expected_start
+    assert backtest.strategy.stack.algos[1].dates == [pd.Timestamp(expected)]
+
+
 def test_run_weekly():
     dts = pd.date_range("2010-01-01", periods=367)
     data = pd.DataFrame(index=dts, columns=["c1", "c2"], data=100)

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -148,15 +148,21 @@ def test_run_daily():
 
 
 @pytest.mark.parametrize(
-    "start,expected_start,expected_end",
+    "dates,expected_start,expected_end",
     [
-        ("2015-12-28", "2016-01-04", "2016-01-03"),
-        ("2018-12-28", "2018-12-31", "2018-12-30"),
+        (pd.date_range("2015-12-28", periods=9), "2016-01-04", "2016-01-03"),
+        (pd.date_range("2018-12-28", periods=9), "2018-12-31", "2018-12-30"),
+        (
+            pd.to_datetime(["2018-12-27", "2018-12-28", "2018-12-31", "2019-01-02", "2019-01-03"]),
+            "2018-12-31",
+            "2018-12-28",
+        ),
     ],
 )
 @pytest.mark.parametrize("run_on_end_of_period", [False, True])
+@pytest.mark.parametrize("timezone", [None, "America/New_York"])
 def test_run_weekly_does_not_split_an_iso_week_at_new_year(
-    start, expected_start, expected_end, run_on_end_of_period
+    dates, expected_start, expected_end, run_on_end_of_period, timezone
 ):
     class RecordDates(bt.Algo):
         def __init__(self):
@@ -166,7 +172,7 @@ def test_run_weekly_does_not_split_an_iso_week_at_new_year(
             self.dates.append(target.now)
             return True
 
-    data = pd.DataFrame({"asset": 100.0}, index=pd.date_range(start, periods=9))
+    data = pd.DataFrame({"asset": 100.0}, index=dates.tz_localize(timezone))
     strategy = bt.Strategy(
         "weekly",
         [
@@ -181,7 +187,7 @@ def test_run_weekly_does_not_split_an_iso_week_at_new_year(
     backtest.run()
 
     expected = expected_end if run_on_end_of_period else expected_start
-    assert backtest.strategy.stack.algos[1].dates == [pd.Timestamp(expected)]
+    assert backtest.strategy.stack.algos[1].dates == [pd.Timestamp(expected, tz=timezone)]
 
 
 def test_run_weekly():


### PR DESCRIPTION
## Summary

`RunWeekly` can trigger an extra strategy execution on January 1 even when the ISO week has not changed. Compare the ISO year together with the ISO week so a weekly rebalance stays on the intended boundary.

The regression runs real backtests across the 2015/2016 and 2018/2019 boundaries, checking both beginning-of-week and end-of-week scheduling.

## Validation

- All four regression cases fail before the fix.
- Full suite: 241 passed, 87.08% coverage, on Windows with Python 3.11.9.
- Repository Ruff check/format targets, source and compiled Windows wheel builds, and distribution-content checks passed.

## Post-Deploy Monitoring & Validation

No service deployment is involved. Check weekly execution dates around New Year when comparing backtest results across versions; the extra calendar-year trigger is removed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
