### PR TITLE
Preserve random benchmark dates

### DIFF
--- a/bt/backtest.py
+++ b/bt/backtest.py
@@ -51,6 +51,9 @@ def benchmark_random(backtest, random_strategy, nsim=100):
     randomly picking weight? Or randomly picking the selected
     securities?
 
+    Random backtests preserve every date from the original supplied
+    market data, including dates with partial missing values.
+
     Args:
         * backtest (Backtest): A backtest you want to benchmark
         * random_strategy (Strategy): A strategy you want to benchmark
@@ -72,7 +75,8 @@ def benchmark_random(backtest, random_strategy, nsim=100):
 
     bts = []
     bts.append(backtest)
-    data = backtest.data.dropna()
+    # Remove only Backtest's synthetic first row without dropping real partial rows.
+    data = backtest.data.iloc[1:]
 
     # create and run random backtests
     for i in tqdm(range(nsim)):

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -162,6 +162,36 @@ def test_can_disable_progress_bar_from_run():
     assert  len(result.get_transactions()) > 0
 
 
+def test_benchmark_random_preserves_partial_missing_dates():
+    dates = pd.date_range("2020-01-01", periods=4)
+    data = pd.DataFrame(
+        {"a": [100.0, 150.0, 75.0, 100.0], "unused": [100.0, 100.0, np.nan, 100.0]},
+        index=dates,
+    )
+
+    # Both strategies select only a, so missing data for the unused asset cannot change returns.
+    def make_strategy(name: str) -> bt.Strategy:
+        return bt.Strategy(
+            name,
+            [
+                bt.algos.RunOnce(),
+                bt.algos.SelectThese(["a"]),
+                bt.algos.WeighEqually(),
+                bt.algos.Rebalance(),
+            ],
+        )
+
+    backtest = bt.Backtest(make_strategy("original"), data, progress_bar=False)
+    result = bt.backtest.benchmark_random(backtest, make_strategy("random"), nsim=1)
+    random_backtest: bt.Backtest = result.backtests["random_0"]
+
+    # Reconstructing a Backtest must replace only its synthetic row and preserve the real timeline.
+    pd.testing.assert_frame_equal(random_backtest.data, backtest.data)
+    expected_drawdown = 75.0 / 150.0 - 1.0
+    assert result.stats.loc["max_drawdown", "original"] == pytest.approx(expected_drawdown)
+    assert result.stats.loc["max_drawdown", "random_0"] == pytest.approx(expected_drawdown)
+
+
 def test_Results_helper_functions():
 
     names = ["foo", "bar"]

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -162,12 +162,15 @@ def test_can_disable_progress_bar_from_run():
     assert  len(result.get_transactions()) > 0
 
 
-def test_benchmark_random_preserves_partial_missing_dates():
+@pytest.mark.parametrize("missing_position", [0, 2, 3])
+@pytest.mark.parametrize("already_run", [False, True])
+def test_benchmark_random_preserves_partial_missing_dates(missing_position, already_run):
     dates = pd.date_range("2020-01-01", periods=4)
     data = pd.DataFrame(
-        {"a": [100.0, 150.0, 75.0, 100.0], "unused": [100.0, 100.0, np.nan, 100.0]},
+        {"a": [100.0, 150.0, 75.0, 100.0], "unused": 100.0},
         index=dates,
     )
+    data.loc[dates[missing_position], "unused"] = np.nan
 
     # Both strategies select only a, so missing data for the unused asset cannot change returns.
     def make_strategy(name: str) -> bt.Strategy:
@@ -182,14 +185,30 @@ def test_benchmark_random_preserves_partial_missing_dates():
         )
 
     backtest = bt.Backtest(make_strategy("original"), data, progress_bar=False)
-    result = bt.backtest.benchmark_random(backtest, make_strategy("random"), nsim=1)
-    random_backtest: bt.Backtest = result.backtests["random_0"]
+    if already_run:
+        backtest.run()
+    original_data = backtest.data.copy(deep=True)
+    result = bt.backtest.benchmark_random(backtest, make_strategy("random"), nsim=2)
 
     # Reconstructing a Backtest must replace only its synthetic row and preserve the real timeline.
-    pd.testing.assert_frame_equal(random_backtest.data, backtest.data)
+    pd.testing.assert_frame_equal(backtest.data, original_data)
     expected_drawdown = 75.0 / 150.0 - 1.0
     assert result.stats.loc["max_drawdown", "original"] == pytest.approx(expected_drawdown)
-    assert result.stats.loc["max_drawdown", "random_0"] == pytest.approx(expected_drawdown)
+    for name in ["random_0", "random_1"]:
+        pd.testing.assert_frame_equal(result.backtests[name].data, original_data)
+        assert result.stats.loc["max_drawdown", name] == pytest.approx(expected_drawdown)
+
+
+def test_benchmark_random_preserves_all_missing_dates():
+    dates = pd.date_range("2020-01-01", periods=5, tz="UTC")
+    data = pd.DataFrame({"a": [np.nan, 100.0, np.nan, 110.0, np.nan]}, index=dates)
+    # Stay in cash so an entirely missing real row does not require pricing a holding.
+    backtest = bt.Backtest(bt.Strategy("original"), data, progress_bar=False)
+    result = bt.backtest.benchmark_random(backtest, bt.Strategy("random"), nsim=2)
+
+    for name in ["original", "random_0", "random_1"]:
+        pd.testing.assert_frame_equal(result.backtests[name].data, backtest.data)
+        pd.testing.assert_index_equal(result.backtests[name].dates[1:], dates)
 
 
 def test_Results_helper_functions():


### PR DESCRIPTION
## Summary

Build random benchmark controls from every original supplied date rather than dropping real rows that contain an unrelated missing security value.

With A prices `100, 150, 75, 100`, a missing B price on the third date, and both strategies selecting only A, the original retains the 50% drawdown but the random control silently removes the trough.

## Behavior

Random benchmarking may randomize strategy logic but must preserve the original market timeline; an unused security's missing value cannot alter another selected security's return path.

## Regression evidence

Fail-before at current accepted commit `3985b484` gives four original dates and maximum drawdown `-0.5`, but only three control dates and drawdown `-0.33333333333333337`. The independent identical-A-path oracle is four dates and `-0.5` for both. The permanent regression failed before the fix with processed shapes `(4, 2)` versus `(5, 2)`. Removing `backtest.data`'s first row by position now restores exact processed-data equality, the full selected-A price path, and drawdown `-0.5` for both public result columns.

## Verification

- Focused regression: The permanent test failed before production changed with a `(4, 2)` versus `(5, 2)` frame mismatch and passes afterward (`1 passed`), including exact processed-data and independently derived public drawdown assertions.
- Complete affected subsystem: Final `tests/test_backtest.py` passes (`37 passed`) with 18 inherited pandas copy-on-write warnings.
- Final full suite: Native `make lint` passes, including Ruff, formatting, Markdown formatting, and codespell; native `make test` passes all 238 tests with 48 inherited pandas copy-on-write warnings.
- Static, documentation, API, dependency, or build checks: Differential Ruff reports zero new and seven inherited diagnostics. Changed-line Pyright reports zero unapproved diagnostics and 233 inherited or indirect diagnostics. `bt/backtest.py` remains formatter-clean; `tests/test_backtest.py` retains only accepted formatting debt, with no changed-line churn. `format-new` found no added Python files, and `git diff --check` passes. The repository-wide impact scan found no derived documentation, examples, snapshots, or generated records.

## Scope

Changed files are limited to `bt/backtest.py` and `tests/test_backtest.py`.

Out of scope: Missing-price selection policy, imputation, result-statistics definitions, and preservation of other `Backtest` configuration tracked separately.