### PR TITLE
Phase out omitted rebalance targets

### DIFF
--- a/bt/algos.py
+++ b/bt/algos.py
@@ -1924,7 +1924,8 @@ class RebalanceOverTime(Algo):
     weight over n periods.
 
     Rebalances towards a target weight over a n periods. Splits up the weight
-    delta over n periods.
+    delta over n periods. Current children omitted from the target weights are
+    treated as zero-weight targets and phased out over the same periods.
 
     This can be useful if we want to make more conservative rebalacing
     assumptions. Some strategies can produce large swings in allocations. It
@@ -1966,12 +1967,18 @@ class RebalanceOverTime(Algo):
         # if _weights are not None, we have some work to do
         if self._weights is not None:
             tgt = {}
-            # scale delta relative to # of periods left and set that as the new
-            # target
-            for cname in self._weights:
+            # Read mapping entries by key and preserve their supplied order.
+            for cname, target_weight in self._weights.items():
                 curr = target.children[cname].weight if cname in target.children else 0.0
-                dlt = (self._weights[cname] - curr) / self._days_left
+                dlt = (target_weight - curr) / self._days_left
                 tgt[cname] = curr + dlt
+
+            # Rebalance would otherwise close omitted holdings immediately.
+            for cname in target.children:
+                if cname not in tgt:
+                    curr = target.children[cname].weight
+                    dlt = -curr / self._days_left
+                    tgt[cname] = curr + dlt
 
             # mock weights and call real Rebalance
             target.temp["weights"] = tgt

--- a/bt/algos.py
+++ b/bt/algos.py
@@ -1924,8 +1924,9 @@ class RebalanceOverTime(Algo):
     weight over n periods.
 
     Rebalances towards a target weight over a n periods. Splits up the weight
-    delta over n periods. Current children omitted from the target weights are
-    treated as zero-weight targets and phased out over the same periods.
+    delta over n periods. Current children with nonzero weights omitted from the
+    targets are phased out over the same periods. Omitted zero-weight hedges
+    remain untouched.
 
     This can be useful if we want to make more conservative rebalacing
     assumptions. Some strategies can produce large swings in allocations. It
@@ -1977,6 +1978,8 @@ class RebalanceOverTime(Algo):
             for cname in target.children:
                 if cname not in tgt:
                     curr = target.children[cname].weight
+                    if curr == 0.0:
+                        continue
                     dlt = -curr / self._days_left
                     tgt[cname] = curr + dlt
 

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -1783,6 +1783,64 @@ def test_rebalance_over_time():
     assert rb.call_count == 2
 
 
+def test_rebalance_over_time_phases_out_omitted_target():
+    target = mock.MagicMock()
+    rb = mock.MagicMock()
+
+    algo = algos.RebalanceOverTime(n=2)
+    algo._rb = rb
+
+    target.temp = {"weights": {"a": 1.0}}
+    a = mock.MagicMock()
+    a.weight = 0.5
+    b = mock.MagicMock()
+    b.weight = 0.5
+    target.children = {"a": a, "b": b}
+
+    assert algo(target)
+
+    # Sparse and explicit-zero targets must follow the same interpolation path.
+    assert list(target.temp["weights"]) == ["a", "b"]
+    assert target.temp["weights"] == pytest.approx({"a": 0.75, "b": 0.25})
+    assert rb.call_args[0][0] is target
+
+
+def test_rebalance_over_time_supports_sparse_weigh_target():
+    dates = pd.date_range("2020-01-01", periods=4)
+    prices = pd.DataFrame(
+        {"a": [100.0, 100.0, 100.0, 100.0], "b": [100.0, 100.0, 100.0, 200.0]},
+        index=dates,
+    )
+    targets = pd.DataFrame({"a": [0.5, 1.0], "b": [0.5, np.nan]}, index=dates[[0, 2]])
+    strategy = bt.Strategy(
+        "s",
+        [
+            algos.WeighTarget("targets"),
+            algos.run_always(algos.RebalanceOverTime(n=2)),
+        ],
+    )
+    backtest = bt.Backtest(
+        strategy,
+        prices,
+        initial_capital=1000.0,
+        integer_positions=False,
+        additional_data={"targets": targets},
+    )
+
+    bt.run(backtest)
+
+    # The first plan reaches 50/50 before the sparse target starts phasing out b.
+    a = backtest.strategy.children["a"]
+    b = backtest.strategy.children["b"]
+    assert [a.positions.loc[dates[1]], b.positions.loc[dates[1]]] == pytest.approx([5.0, 5.0])
+    assert [a.positions.loc[dates[2]], b.positions.loc[dates[2]]] == pytest.approx([7.5, 2.5])
+    assert backtest.strategy.cash.loc[dates[2]] == pytest.approx(0.0)
+
+    # Holding 2.5 shares of b through its price change independently yields 1,250.
+    assert backtest.strategy.value == pytest.approx(1250.0)
+    assert backtest.strategy.price == pytest.approx(125.0)
+
+
 def test_require():
     target = mock.MagicMock()
     target.temp = {}

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -1805,6 +1805,41 @@ def test_rebalance_over_time_phases_out_omitted_target():
     assert rb.call_args[0][0] is target
 
 
+@pytest.mark.parametrize("hedge_type", [bt.HedgeSecurity, bt.CouponPayingHedgeSecurity])
+@pytest.mark.parametrize("close_hedge", [False, True])
+def test_rebalance_over_time_preserves_omitted_hedges(hedge_type, close_hedge):
+    dates = pd.date_range("2020-01-01", periods=2)
+    prices = pd.DataFrame(100.0, index=dates, columns=["a", "b", "hedge"])
+    strategy = bt.FixedIncomeStrategy(
+        "s", children=[bt.CouponPayingSecurity("a"), bt.CouponPayingSecurity("b"), hedge_type("hedge")]
+    )
+    strategy.use_integer_positions(False)
+    strategy.setup(prices, coupons=prices * 0.0)
+    strategy.adjust(10000.0)
+    strategy.update(dates[0])
+    strategy["a"].transact(5)
+    strategy["b"].transact(5)
+    strategy["hedge"].transact(-2)
+    strategy.update(dates[0])
+    assert strategy["hedge"].weight == 0.0
+
+    algo = algos.RebalanceOverTime(n=2)
+    strategy.temp["weights"] = {"a": 1.0}
+    if close_hedge:
+        strategy.temp["weights"]["hedge"] = 0.0
+    assert algo(strategy)
+    assert strategy["a"].position == pytest.approx(7.5)
+    assert strategy["b"].position == pytest.approx(2.5)
+    assert strategy["hedge"].position == (0 if close_hedge else -2)
+
+    strategy.temp = {}
+    strategy.update(dates[1])
+    assert algo(strategy)
+    assert strategy["a"].position == pytest.approx(10.0)
+    assert strategy["b"].position == 0.0
+    assert strategy["hedge"].position == (0 if close_hedge else -2)
+
+
 def test_rebalance_over_time_supports_sparse_weigh_target():
     dates = pd.date_range("2020-01-01", periods=4)
     prices = pd.DataFrame(


### PR DESCRIPTION
## Summary

Make `RebalanceOverTime` interpolate over the ordered union of supplied target keys and existing children, reading dict and Series weights by key and treating every omitted current child as a zero final target.

Starting from 50% A and 50% B, target `{"A": 1.0}` over two periods produces 75% A, 0% B, and 25% cash on the first step; the equivalent explicit target `{"A": 1.0, "B": 0.0}` correctly produces 75% A, 25% B, and no cash. If B doubles before the second step, the sparse path ends at value/index `1,000/100` while the explicit path and independent hold-2.5-shares oracle end at `1,250/125`. The public `WeighTarget` path independently fails on its first gradual step with `KeyError: 1.0` because pandas Series iteration yields values.

## Behavior

Sparse and explicit-zero representations of one final target must follow the same gradual path, and every mapping accepted from bt's own weighting Algos must be interpreted by security key rather than by iterated value.

## Regression evidence

Both mechanisms were confirmed at accepted commit `3985b484`. Independent first-step interpolation is `(0.5 + (1 - 0.5) / 2, 0.5 + (0 - 0.5) / 2) = (0.75, 0.25)`. Before the fix, the new direct sparse-dict regression produced only `{'a': 0.75}` instead of `{'a': 0.75, 'b': 0.25}`, and the public `WeighTarget` backtest raised `KeyError: 0.5` while reading its first Series row. After the fix, both permanent regressions pass and the backtest follows positions `5/5` to `7.5/2.5`, retains zero intermediate cash, and reaches independently reconstructed value/index `1,250/125` when B doubles.

## Verification

- Focused regression: Both new permanent regressions and the existing explicit-zero control pass together on the rebased commit (`3 passed`).
- Complete affected subsystem: `tests/test_algos.py` passes (`125 passed`, nine inherited pandas chained-assignment warnings).
- Final full suite: Native `make test` passes (`261 passed`, 48 inherited pandas chained-assignment warnings) on the exact rebased commit.
- Static, documentation, API, dependency, or build checks: Differential Ruff reports zero new findings and 20 inherited test-file findings; `bt/algos.py` is formatter-clean, while `tests/test_algos.py` retains accepted format debt with its changed lines manually conformed. Changed-line Pyright reports zero unapproved diagnostics and 653 inherited or indirect diagnostics. Native `make lint` and `git diff --check` pass, format-new found no added Python files, and the repository-wide downstream scan found no pinned result, generated record, build consequence, signature, dependency, export, or Cython impact. No distribution build is required because this pure-Python Algo change does not affect packaging or Cythonized core behavior.

## Scope

Changed files are limited to `bt/algos.py`, `tests/test_algos.py`.

Out of scope: Scheduling or `run_always` semantics, redesigning `Rebalance`, transaction-cost optimization, and unrelated sparse-weight Algos.