### PR TITLE
Preserve filtered universe order

### DIFF
--- a/bt/core.py
+++ b/bt/core.py
@@ -631,11 +631,10 @@ class StrategyBase(Node):
         # funiverse will be empty, to signal that no other ticker should be
         # used in addition to the strategies
         if self._original_children_are_present:
-            # if we have universe_tickers defined, limit universe to
-            # those tickers
-            valid_filter = list(set(universe.columns).intersection(self._universe_tickers))
+            # Limit the universe by name while preserving its original column order.
+            valid_filter = universe.columns.isin(self._universe_tickers)
 
-            funiverse = universe[valid_filter].copy()
+            funiverse = universe.loc[:, valid_filter].copy()
 
             # if we have strat children, we will need to create their columns
             # in the new universe

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@ from __future__ import division
 
 import copy
 import pickle
+import random
 
 import numpy as np
 import pandas as pd
@@ -15,6 +16,13 @@ from bt.core import FixedIncomeStrategy, HedgeSecurity, FixedIncomeSecurity
 from bt.core import CouponPayingSecurity, CouponPayingHedgeSecurity
 from bt.core import is_zero
 from bt.core import CostModel, SqrtCostModel, AlmgrenChrissCostModel
+
+
+class DeterministicHashString(str):
+    """Provide stable hashes that expose unordered universe filtering."""
+
+    def __hash__(self) -> int:
+        return "AEBDCZ".index(self)
 
 
 @pytest.mark.parametrize("security_type", [bt.Security, CouponPayingSecurity])
@@ -2133,6 +2141,70 @@ def test_strategy_tree_proper_universes():
     assert child2.get_data("test_data2") == "test2"
 
     assert len(parent._strat_children) == 2
+
+
+def test_explicit_children_preserve_universe_order_for_seeded_results():
+    """Keep seeded selection and results stable after restricting the universe."""
+
+    dates = pd.date_range("2020-01-01", periods=2)
+    tickers = [DeterministicHashString(name) for name in "ABCDE"]
+    prices = pd.DataFrame(
+        [[100.0] * 5, [110.0, 120.0, 130.0, 140.0, 150.0]],
+        index=dates,
+        columns=pd.Index(tickers, dtype=object),
+    )
+    children = list(reversed(tickers)) + [DeterministicHashString("Z")]
+    strategy = Strategy(
+        "seeded",
+        [
+            bt.algos.RunOnce(),
+            bt.algos.SelectAll(),
+            bt.algos.SelectRandomly(n=2),
+            bt.algos.WeighEqually(),
+            bt.algos.Rebalance(),
+        ],
+        children=children,
+    )
+    backtest = bt.Backtest(
+        strategy,
+        prices,
+        initial_capital=1000.0,
+        integer_positions=False,
+        progress_bar=False,
+    )
+
+    # Preserve the global generator for other tests while exercising the documented seed path.
+    random_state = random.getstate()
+    random.seed(271828)
+    try:
+        backtest.run()
+    finally:
+        random.setstate(random_state)
+
+    strategy = backtest.strategy
+    # B and A return 20% and 10%, so their equal-weighted index must finish at 115.
+    assert strategy.prices.iloc[-1] == pytest.approx(115.0)
+    assert strategy._universe.columns.tolist() == tickers
+
+
+def test_explicit_children_preserve_universe_order_with_strategy_child():
+    """Append Strategy children after source-ordered security columns."""
+
+    tickers = [DeterministicHashString(name) for name in "ABCDE"]
+    data = pd.DataFrame(
+        [[1.0] * 5],
+        index=pd.date_range("2020-01-01", periods=1),
+        columns=pd.Index(tickers, dtype=object),
+    )
+    child = Strategy("child")
+    parent = Strategy(
+        "parent",
+        children=[tickers[4], child, tickers[2], tickers[0], DeterministicHashString("Z")],
+    )
+
+    parent.setup(data)
+
+    assert parent._universe.columns.tolist() == [tickers[0], tickers[2], tickers[4], "child"]
 
 
 @pytest.mark.parametrize("restore", [lambda node: node, copy.deepcopy, lambda node: pickle.loads(pickle.dumps(node))], ids=["original", "deepcopy", "pickle"])


### PR DESCRIPTION
## Summary

Preserve original universe-column order when restricting a Strategy to explicitly declared children so deterministic order-sensitive Algos remain reproducible.

With explicit children A–E and identical `random.seed(271828)`, changing only `PYTHONHASHSEED` changes the filtered universe, `SelectRandomly(n=2)` output, and a two-period portfolio's final price from 115 through 140.

## Behavior

Explicit children restrict the supplied labeled universe without changing the relative order of retained source columns. Identical labeled inputs and an identical random seed must therefore produce the same security selection and portfolio result across Python processes. Child declaration order is not promoted to a separate public ordering contract.

## Regression evidence

- On accepted `2ab842dd97127bc1ba30d643ffa55f28ba28beb3` with Python 3.11.16 and the compiled `bt/core.cpython-311-darwin.so`, the same realistic Backtest and `random.seed(271828)` produced universe/selection/final-price outcomes `A,E,B,D,C`/`E,A`/130 (hash seed 0), `A,C,B,D,E`/`C,A`/120 (1), `A,E,C,B,D`/`E,A`/130 (2), `A,C,D,E,B`/`C,A`/120 (3), `C,E,D,B,A`/`E,C`/140 (4), `D,A,C,B,E`/`A,D`/125 (5), `A,B,C,E,D`/`B,A`/115 (42), and `E,B,C,A,D`/`B,E`/135 (271828).
- The independent oracle filters source columns A–E in place, after which `random.Random(271828).sample(list("ABCDE"), 2)` selects `B,A`; equal initial weights and second-period returns of 20% and 10% give the unique expected final price 115.
- At `PYTHONHASHSEED=1`, all five supported regression bands reproduced unstable set ordering: pandas 1.5.3/NumPy 1.26.4 and pandas 2.3.3 with NumPy 1.26.4 or 2.4.6 returned `E,A,C`, while pandas 3.0.5 with NumPy 1.26.4 or 2.4.6 returned `C,E,A`. A pandas column-membership mask returned the source order `E,C,A`, retained the Index name, and preserved duplicate labels in every band.
- Pass-after: replacing the set intersection with a source-index membership mask preserves the exact source columns `A,B,C,D,E`; the same seeded backtest finishes at the independently derived price 115, and the mixed security/Strategy case retains `A,C,E,child`.

## Verification

- Focused fail-before: both permanent tests failed against accepted source before the production edit. The end-to-end test produced final price 130 instead of 115 and source columns `A,E,B,D,C` instead of `A,B,C,D,E`; the mixed case produced `A,E,C,child` instead of `A,C,E,child`. The deterministic hash-string fixture makes the historical set-order failure reproducible without depending on the test process's hash seed.
- Focused pass-after: both permanent tests pass on the final source. A separate downstream scan ran `test_select_randomly`, `test_weigh_randomly`, and the dynamic nested CostModel setup test; all 3 passed.
- Complete affected subsystem: all 112 tests in `tests/test_core.py` pass.
- Full repository verification: native `make lint` passes and all 291 tests pass. The run reports 51 accepted pandas copy-on-write warnings; the new mixed-child regression deliberately reaches one already-known Strategy-child assignment warning, whose production cleanup is outside this ordering fix.
- Static, formatting, and scope checks: `git diff --check` passes; baseline-aware Ruff reports 0 new and 12 inherited diagnostics; changed-line Pyright 1.1.411 reports 0 unapproved and 664 inherited or indirect diagnostics. `bt/core.py` is formatter-clean, the changed test block is manually confirmed formatter-clean, and the rest of `tests/test_core.py` retains its accepted formatter debt. Both `format-new` preview and execution report no added Python files. The diff remains limited to `bt/core.py` and `tests/test_core.py` with no public signature, dependency, export, or documentation change.
- Compatibility and compiled behavior: the assessment's five supported pandas/NumPy bands all validated the membership-mask behavior. `make dist` built and Twine-checked the Cythonized wheel and source distribution, and `make test-dist` verified installed-wheel imports plus a wheel rebuilt from the source distribution. The expected pre-existing setuptools license warnings remain non-failing.

## Scope

Changed files are limited to `bt/core.py`, `tests/test_core.py` only. No Algo, public signature, documentation, dependency, or export change is justified.

Out of scope: Making child declaration order override source order, global ordering guarantees for user-supplied sets, duplicate-column support, random-number-generator redesign, Algo changes, existing pandas 3 Strategy-child assignment warnings, and unrelated child-tree performance work.