### PR TITLE
Respect security multipliers in PTE_Rebalance

### DIFF
--- a/bt/algos.py
+++ b/bt/algos.py
@@ -1605,6 +1605,9 @@ class PTE_Rebalance(Algo):
     """
     Triggers a rebalance when PTE from static weights is past a level.
 
+    Current weights include each Security's multiplier when converting
+    position quantities to portfolio value.
+
     Args:
         * PTE_volatility_cap: annualized volatility to target
         * target_weights: dataframe of weights that needs to have the same index as the price dataframe
@@ -1647,7 +1650,9 @@ class PTE_Rebalance(Algo):
         if prices is None:
             return True
 
-        current_weights = positions * prices / target.value
+        # Convert contract quantities to economic exposure before comparing weights.
+        multipliers = pd.Series({security.name: security.multiplier for security in target.securities})
+        current_weights = positions * prices * multipliers / target.value
 
         target_weights = self.target_weights.loc[target.now, :]
 

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -2215,6 +2215,42 @@ def test_PTE_Rebalance(covar_method):
     assert not PTE_rebalance_Algo(s)
 
 
+@pytest.mark.parametrize("multiplier", [1, 10])
+def test_PTE_Rebalance_security_multiplier(multiplier: int):
+    dates = pd.date_range("2010-01-01", periods=8)
+    data = pd.DataFrame(
+        {
+            "c1": [100, 105, 95, 110, 90, 115, 105, 120],
+            "c2": [100, 99, 101, 98, 102, 97, 103, 100],
+        },
+        index=dates,
+    )
+    strategy = bt.Strategy(
+        "s",
+        children=[bt.Security("c1", multiplier=multiplier), bt.Security("c2")],
+    )
+    strategy.use_integer_positions(False)
+    strategy.setup(data)
+    strategy.update(dates[-1])
+    strategy.adjust(1_000_000)
+    strategy.rebalance(0.4, "c1")
+    strategy.rebalance(0.6, "c2")
+    target_weights = pd.DataFrame({"c1": 0.4, "c2": 0.6}, index=dates)
+    algo = bt.algos.PTE_Rebalance(
+        0.01,
+        target_weights,
+        lookback=pd.DateOffset(days=6),
+        lag=pd.DateOffset(days=1),
+    )
+
+    # Independently reconstruct economic weights from quantities and contract sizes.
+    c1_weight: float = strategy["c1"].position * 120 * multiplier / strategy.value
+    c2_weight: float = strategy["c2"].position * 100 / strategy.value
+    assert c1_weight == pytest.approx(0.4)
+    assert c2_weight == pytest.approx(0.6)
+    assert not algo(strategy)
+
+
 def test_TargetVol_standard_uses_pairwise_covariance():
     s = bt.Strategy("s")
 


### PR DESCRIPTION
## Summary

Include each security multiplier when `PTE_Rebalance` reconstructs current portfolio weights so economically equivalent representations produce the same trigger.

In equivalent value-1,000,000 portfolios with 40% in `c1` and 60% in `c2`, multiplier-one and multiplier-ten `c1` securities have quantities `3478.2608695652175` and `347.82608695652175` at price 115, respectively. Both have economic weight 40%, but before this fix only the multiplier-ten representation triggers a rebalance against the already satisfied 40%/60% target.

## Behavior

Predicted tracking error and its Boolean trigger are invariant to equivalent contract-quantity/multiplier representations.

## Regression evidence

At assessment commit `2ab842dd97127bc1ba30d643ffa55f28ba28beb3`, the multiplier-one representation reconstructs weights `0.4/0.6`, calculates zero PTE, and returns `False`. The multiplier-ten representation reconstructs `0.04/0.6`, calculates `0.5761242001594951` annualized standard-covariance PTE, and incorrectly returns `True`; its independent multiplier-aware PTE is zero. Ledoit-Wolf gives the same wrong decision with `0.5729145696139869` PTE. A disposable pytest asserting the correct `False` result fails exactly as `True == False`. After the scoped fix, both representations reconstruct `0.4/0.6`, calculate zero PTE, and return `False`.

## Verification

- Focused regression: The disposable fail-before pytest failed for the intended `True == False` reason while the multiplier-one control passed. On the final source, the accepted standard and Ledoit-Wolf cells and the new multiplier-one/multiplier-ten cells all pass: four passed, with twelve inherited pandas copy-on-write warnings.
- Complete affected subsystem: `tests/test_algos.py` passes all 131 tests with 13 inherited pandas copy-on-write warnings.
- Final full suite: Native `make lint` and `make checks` pass; `make coverage` passes all 293 repository tests with 55 inherited pandas copy-on-write warnings.
- Static baseline: Ruff 0.16.4 reports zero new diagnostics and 20 inherited test-file diagnostics. `bt/algos.py` remains formatted; the only test-file format mismatch is inherited and no changed line is implicated. Changed-line Pyright 1.1.411 reports zero unapproved or maintainer-authorized diagnostics and 657 inherited or indirect diagnostics. `git diff --check` passes.
- Documentation, API, dependency, or build checks: The `PTE_Rebalance` docstring now states the multiplier-aware contract. The routed documentation and repository-wide downstream scan found no example, notebook, generated record, public signature, export, dependency, or build output requiring another change. `bt/algos.py` is not Cythonized.

## Scope

Changed files are limited to `bt/algos.py`, `tests/test_algos.py`

Out of scope: Covariance-method changes, `TargetVol`, `HedgeRisks`, transaction quantities, and general repeated-name or strategy-of-strategies PTE aggregation.