### PR TITLE
Fix margin maintenance liquidation

### DIFF
--- a/bt/algos.py
+++ b/bt/algos.py
@@ -2551,14 +2551,16 @@ class HedgeRisks(Algo):
 
 class Margin(Algo):
     """
-    Margin allows us to model margin lending using bt. It will periodically charge the strategy
-    a set interest rate and will liquidate its positions if it falls below a specified maintance
-    requirement
+    Model margin lending by periodically charging interest and liquidating a leveraged long
+    portfolio when it falls below a specified maintenance requirement.
+
+    For a portfolio with positive equity, liquidation targets the maintenance requirement when
+    no transaction costs apply. Integer-position constraints may liquidate beyond that boundary.
 
     Args:
         * rate (float): the margin interest rate. i.e: 0.05 -> 5%
         * requirement (float): the maintenance requirement. The algorithm will liquidate the portfolio if the
-        equity in falls below this percentage.
+        equity falls below this percentage.
     """
 
     def __init__(self, rate, requirement):
@@ -2599,9 +2601,9 @@ class Margin(Algo):
             if equity_ratio < self.requirement:
                 max_value = target.value * (1 / self.requirement)
 
-                # liquidate
+                # Strategy.allocate applies the amount through child weights, which sum to port_val / equity.
                 deficit = max_value - port_val
-                target.allocate(deficit / 2)
+                target.allocate(deficit * equity_ratio)
 
         # update our date
         self._last_date = target.now

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -2810,6 +2810,39 @@ def test_margin():
     assert pytest.approx(999.73, 0.001) == s.value
 
 
+@pytest.mark.parametrize(
+    ("leverage", "requirement"),
+    [(1.5, 0.8), (3.0, 0.5)],
+)
+def test_margin_liquidation_scales_with_leverage(leverage: float, requirement: float):
+    algo = algos.Margin(0, requirement)
+    s = bt.Strategy("s", algos=[algos.WeighSpecified(c1=leverage), algos.Rebalance()])
+    # Fractional positions isolate the liquidation formula from integer rounding.
+    s.use_integer_positions(False)
+    dts = pd.date_range("2010-01-01", periods=1)
+    data = pd.DataFrame(index=dts, columns=["c1"], data=1)
+    algo._last_date = dts[0] - timedelta(days=1)
+
+    s.setup(data)
+    s.update(dts[0])
+    s.adjust(1000)
+    s.run()
+
+    equity = s.value
+    invested_value = s["c1"].value
+    assert invested_value == pytest.approx(equity * leverage)
+    assert equity / invested_value < requirement
+
+    algo(s)
+
+    # With no interest or transaction costs, liquidation preserves equity and targets E / R.
+    expected_invested_value = equity / requirement
+    invested_value = s["c1"].value
+    assert s.value == pytest.approx(equity)
+    assert invested_value == pytest.approx(expected_invested_value)
+    assert s.value / invested_value == pytest.approx(requirement)
+
+
 def test_corporate_actions():
     dts = pd.date_range("2010-01-01", periods=3)
 


### PR DESCRIPTION
## Summary

Scale `Margin` liquidation by the current equity-to-invested-value ratio so zero-transaction-cost leveraged long portfolios reach the maintenance boundary without assuming 2x leverage.

With equity 1,000, long invested value 1,500, and an 80% requirement, accepted code liquidates only to 1,312.50 and leaves the account at 76.19%; with equity 1,000, invested value 3,000, and a 50% requirement, it over-liquidates to 1,500 rather than 2,000. In a realistic price-decline path, a 1.5x portfolio falls from an acceptable 66.67% ratio to equity 700 over invested value 1,200; a 60% requirement should leave 1,166.67 invested, but accepted code leaves 1,171.43 and a still-deficient 59.756% ratio.

## Behavior

For a positive-equity leveraged long portfolio with zero transaction costs, let equity be `E`, aggregate direct-child invested value be `P`, and the maintenance requirement be `R`. When `E / P < R`, fractional liquidation must leave `P* = E / R` without changing equity; discrete execution may liquidate farther, but must not remain below the boundary. Do not describe the existing signed child-value sum as gross exposure or extend this claim to mixed long/short portfolios or transaction commissions.

## Regression evidence

At assessment base commit `2ab842dd97127bc1ba30d643ffa55f28ba28beb3`, a disposable parameterized pytest fails both non-2x cells for the intended reason: actual invested values are 1,312.50 versus expected 1,250.00 at 1.5x/80%, and 1,500.00 versus expected 2,000.00 at 3x/50%. The accepted 2x/two-thirds test passes because the hard-coded divisor happens to match its leverage. After replacing the divisor with the current equity ratio, the permanent two-cell regression and accepted control all pass and the independently derived ratios are exactly 0.8, two-thirds, and 0.5.

## Verification

- Focused regression: `3 passed` for the two permanent non-2x cells and the accepted `tests/test_algos.py::test_margin` interest-bearing 2x control; before the production fix, the two new cells failed at `1312.5 != 1250.0` and `1500.0 != 2000.0`.
- Complete affected subsystem: `133 passed, 13 warnings` for `tests/test_algos.py`; all warnings are inherited pandas copy-on-write findings outside the changed Margin lines.
- Final full suite: `295 passed, 55 warnings` through the native coverage target after rebase; native lint and repository checks also passed.
- Static baseline: The receipt check reports zero new Ruff diagnostics, 20 inherited Ruff diagnostics, zero unapproved changed-line Pyright diagnostics, and 657 inherited or indirect private-profile diagnostics. `bt/algos.py` remains formatter-clean; `tests/test_algos.py` retains its accepted whole-file format debt, with no formatter diff in the added block.
- Documentation, API, dependency, or build checks: `Margin` is public through the API-overview automodule, and its docstring now states the bounded long-portfolio, positive-equity, zero-transaction-cost contract and integer-position qualification. The repository-wide scan found no dedicated Margin page, example, notebook, generated record, snapshot, export change, dependency change, or Cythonized-core change requiring another edit. The private final-code probe exercised the existing recursive allocation path through the installed `bt/core.cpython-311-darwin.so` extension.

## Scope

Changed files are limited to `bt/algos.py`, `tests/test_algos.py`

Out of scope: Transaction-cost-aware maintenance guarantees, short or mixed long/short margin semantics, validation of `rate` or `requirement`, initial-margin rules, margin-call scheduling, broker-specific liquidation order, borrowing limits, fixed-income strategies, and a general leverage API.