### PR TITLE
Isolate inverse-volatility samples

### DIFF
--- a/bt/algos.py
+++ b/bt/algos.py
@@ -1160,7 +1160,8 @@ class WeighInvVol(Algo):
     Sets the target weights based on ffn's calc_inv_vol_weights. This
     is a commonly used technique for risk parity portfolios. The least
     volatile elements receive the highest weight under this scheme. Weights
-    are proportional to the inverse of their volatility.
+    are proportional to the inverse of their volatility. Each asset's
+    volatility estimate uses its own available returns.
 
     Args:
         * lookback (DateOffset): lookback period for estimating volatility
@@ -1191,7 +1192,7 @@ class WeighInvVol(Algo):
 
         t0 = target.now - self.lag
         prc = target.universe.loc[t0 - self.lookback : t0, selected]
-        returns = prc.to_returns().dropna()
+        returns = prc.to_returns()
         # Explicit axis=0 to compute per-column std and avoid FutureWarning
         # from pandas (axis=None will reduce over both axes in a future version)
         vol = 1.0 / returns.std(axis=0, ddof=1)

--- a/bt/algos.py
+++ b/bt/algos.py
@@ -1195,7 +1195,9 @@ class WeighInvVol(Algo):
         returns = prc.to_returns()
         # Explicit axis=0 to compute per-column std and avoid FutureWarning
         # from pandas (axis=None will reduce over both axes in a future version)
-        vol = 1.0 / returns.std(axis=0, ddof=1)
+        # pandas 1.x reduces nullable columns to an object Series containing pd.NA.
+        # Normalize missing values before NumPy's isinf check.
+        vol = (1.0 / returns.std(axis=0, ddof=1)).fillna(np.nan).astype(float)
         vol[np.isinf(vol)] = np.nan
         tw = vol / vol.sum()
         target.temp["weights"] = tw.dropna()

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -1333,6 +1333,85 @@ def test_weigh_inv_vol():
     assert weights["c2"] == pytest.approx(0.980, 3)
 
 
+def _make_inv_vol_missing_data() -> pd.DataFrame:
+    dates = pd.date_range("2020-01-01", periods=9)
+    returns = pd.DataFrame(
+        {
+            "A": [0, 0.08, -0.04, 0.01, 0.06, -0.03, 0.02, -0.01, 0.03],
+            "B": [0, 0.01, 0.015, -0.005, 0.012, 0.008, -0.004, 0.009, 0.006],
+            "C": [0, 0.03, -0.02, 0.01, 0.04, -0.01, 0.02, -0.015, 0.025],
+        },
+        index=dates,
+    )
+    prices = 100 * (1 + returns).cumprod()
+
+    # Combine complete, gappy, all-missing, and zero-volatility columns.
+    prices["D"] = np.nan
+    prices["E"] = 100.0
+    prices.loc[dates[4], ["C", "E"]] = np.nan
+    return prices
+
+
+@pytest.mark.parametrize("dtype", ["float64", "Float64"])
+def test_weigh_inv_vol_missing_data_is_column_local(dtype: str):
+    prices = _make_inv_vol_missing_data().astype(dtype)
+    strategy = bt.Strategy("s")
+    strategy.setup(prices)
+    strategy.update(prices.index[-1])
+    strategy.temp["selected"] = list(prices.columns)
+
+    algo = algos.WeighInvVol(lookback=pd.DateOffset(days=20), lag=pd.DateOffset(days=0))
+    assert algo(strategy)
+
+    # Calculate the sample volatility from each asset's explicit valid returns.
+    return_samples = [
+        [0.08, -0.04, 0.01, 0.06, -0.03, 0.02, -0.01, 0.03],
+        [0.01, 0.015, -0.005, 0.012, 0.008, -0.004, 0.009, 0.006],
+        [0.03, -0.02, 0.01, 0.02, -0.015, 0.025],
+    ]
+    expected = 1.0 / np.array([np.std(sample, ddof=1) for sample in return_samples])
+    expected /= expected.sum()
+
+    # Missing-only and zero-volatility assets remain excluded from the weights.
+    weights = strategy.temp["weights"]
+    assert isinstance(weights, pd.Series)
+    assert weights.index.tolist() == ["A", "B", "C"]
+    np.testing.assert_allclose(weights.to_numpy(dtype=float), expected)
+
+
+def test_weigh_inv_vol_missing_data_reaches_rebalance():
+    prices = _make_inv_vol_missing_data()
+    final_weights = {}
+
+    # Compare equivalent public stacks with and without the unrelated gappy asset.
+    for columns in (["A", "B"], ["A", "B", "C"]):
+        strategy = bt.Strategy(
+            "s",
+            [
+                algos.RunOnDate(prices.index[-1]),
+                algos.SelectAll(),
+                algos.WeighInvVol(lookback=pd.DateOffset(days=20), lag=pd.DateOffset(days=0)),
+                algos.Rebalance(),
+            ],
+        )
+        backtest = bt.Backtest(
+            strategy,
+            prices.reindex(columns=columns),
+            initial_capital=1_000_000,
+            integer_positions=False,
+            progress_bar=False,
+        )
+        backtest.run()
+        final_weights[tuple(columns)] = {name: backtest.strategy.children[name].weight for name in columns}
+
+    # Adding C may change normalization, but not A's share of unchanged A and B.
+    weights_ab = final_weights[("A", "B")]
+    weights_abc = final_weights[("A", "B", "C")]
+    share_ab = weights_ab["A"] / (weights_ab["A"] + weights_ab["B"])
+    share_abc = weights_abc["A"] / (weights_abc["A"] + weights_abc["B"])
+    assert share_abc == pytest.approx(share_ab)
+
+
 @mock.patch("ffn.calc_mean_var_weights")
 def test_weigh_mean_var(mock_mv):
     algo = algos.WeighMeanVar(lookback=pd.DateOffset(days=5))


### PR DESCRIPTION
## Summary

Estimate each selected asset's inverse-volatility weight from that asset's own available return observations so missing data in another selected asset cannot change its relative weight.

With the same A and B price histories, their normalized A:B share is `0.1130126526` when selected alone but changes to `0.2223735630` when a third asset C with interior missing observations is selected. Accepted code produces A/B/C weights `0.1599569/0.5593592/0.2806839`; independent per-column estimation produces `0.07597145/0.59626699/0.32776156`. The branch-level assessment independently reproduced the same invariant failure with a second fixture: A's share of A+B changes from `0.1476126127` to `0.1659899088` solely because gappy C is selected, while the per-asset oracle remains `0.1476126127`.

## Behavior

`WeighInvVol` documents weights proportional to each selected element's inverse volatility. For unchanged A and B data and sample rules, adding C may change total normalization but must not change A's share of A+B. Lag and lookback boundaries remain unchanged.

## Regression evidence

Preserve the validated A/B/C result above. On the assessment fixture, accepted output is A/B/C `0.1260276830/0.6332213820/0.2407509350`; the independent per-asset and ffn-reference result is `0.1142881121/0.6599554300/0.2257564579`, with zero difference between those two reference paths. A complete panel has zero accepted/reference error. A mixed panel containing complete A/B, interior-gappy C, all-missing D, and gappy zero-volatility E returns an empty mapping in accepted code for both `float64`/`np.nan` and nullable `Float64`/`pd.NA`; the oracle retains A/B/C at the reference weights and excludes D/E. After the fix, both dtype paths retain exactly A/B/C and match the independent weights; the public rebalance stack preserves the independently expected A:B share of `0.1476126127` when gappy C is added.

## Verification

- Focused regression: Fail-before produced `3 failed`; after the fix the parameterized direct and public-stack regressions pass `3` tests.
- Complete affected subsystem: The implementation checkpoint passed `134` tests; after rebasing, `tests/test_algos.py` passes `136` tests with `13` inherited pandas chained-assignment warnings in PTE and transaction-replay paths.
- Final full suite: The post-rebase native coverage suite passes `298` tests with `55` inherited warnings.
- Static, documentation, API, dependency, or build checks: Ruff reports zero new diagnostics and `20` inherited test diagnostics; `bt/algos.py` remains clean. Changed-line Pyright reports zero unapproved diagnostics and `657` inherited or indirect diagnostics. `tests/test_algos.py` retains its accepted formatter debt, while the added lines were manually reconciled to the formatter preview; `git diff --check` passes and `format-new` confirms there are no added Python files. The downstream scan found only compatible documentation and example consumers, and the routed documentation fingerprints remain unchanged. The preceding validation reproduced the failure identically across all five supported pandas/NumPy bands. No dependency, public export, documentation-build, or Cython boundary is involved.

## Scope

Changed files are limited to `bt/algos.py`, `tests/test_algos.py`

Out of scope: Covariance-based `WeighERC` and `WeighMeanVar`, price imputation, issue #460's natural-date versus bar-date lookback, scheduling or lag changes, selection policy, and a general missing-data redesign. Do not change the one-selected-asset shortcut in this PR.